### PR TITLE
feat: NFT documentation section — creators, sellers, buyers, marketplace builders

### DIFF
--- a/src/app/nft/buyers/page.tsx
+++ b/src/app/nft/buyers/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import NftBuyers from '@/components/nft/NftBuyers';
+import styles from '@/styles/nft.module.css';
+
+export const metadata = {
+  title: 'NFTs for buyers — Pact Community Organization',
+  description: 'Sign the exact price and nothing else — settlement the contract proves.',
+};
+
+const Page = () => {
+  return (
+    <div className={styles.container}>
+      <NftBuyers />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/nft/creators/page.tsx
+++ b/src/app/nft/creators/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import NftCreators from '@/components/nft/NftCreators';
+import styles from '@/styles/nft.module.css';
+
+export const metadata = {
+  title: 'NFTs for creators — Pact Community Organization',
+  description: 'Mint NFTs with chain-enforced royalties and unforgeable identity.',
+};
+
+const Page = () => {
+  return (
+    <div className={styles.container}>
+      <NftCreators />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/nft/marketplaces/page.tsx
+++ b/src/app/nft/marketplaces/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import NftMarketplaces from '@/components/nft/NftMarketplaces';
+import styles from '@/styles/nft.module.css';
+
+export const metadata = {
+  title: 'Build an NFT marketplace — Pact Community Organization',
+  description: 'Launch a marketplace on the framework (deploy nothing) or implement the standard.',
+};
+
+const Page = () => {
+  return (
+    <div className={styles.container}>
+      <NftMarketplaces />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/nft/page.tsx
+++ b/src/app/nft/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import NftOverview from '@/components/nft/NftOverview';
+import styles from '@/styles/nft.module.css';
+
+export const metadata = {
+  title: 'NFTs on Pact — Pact Community Organization',
+  description: 'The PCO NFT standard and framework — documentation for creators, sellers, buyers, and marketplace builders.',
+};
+
+const Page = () => {
+  return (
+    <div className={styles.container}>
+      <NftOverview />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/nft/sellers/page.tsx
+++ b/src/app/nft/sellers/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import NftSellers from '@/components/nft/NftSellers';
+import styles from '@/styles/nft.module.css';
+
+export const metadata = {
+  title: 'NFTs for sellers — Pact Community Organization',
+  description: 'Fixed-price sales and auctions with economics that cannot change after you sign.',
+};
+
+const Page = () => {
+  return (
+    <div className={styles.container}>
+      <NftSellers />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/components/docs/DocsHub.tsx
+++ b/src/components/docs/DocsHub.tsx
@@ -3,6 +3,13 @@ import styles from '@/styles/docs.module.css';
 
 const links = [
   {
+    title: 'NFT Documentation',
+    url: '/nft',
+    description:
+      'The PCO NFT standard and framework — guides for creators, sellers, buyers, and businesses building their own marketplace.',
+    internal: true,
+  },
+  {
     title: 'Pact Documentation',
     url: 'https://docs.pact.io/reference',
     description: 'The official documentation for the Pact smart contract language.',
@@ -31,7 +38,13 @@ const DocsHub = () => {
       <p>Everything you need to build with Pact, in one place.</p>
       <div className={styles.grid}>
         {links.map((link, index) => (
-          <a key={index} href={link.url} target="_blank" rel="noopener noreferrer" className={styles.card}>
+          <a
+            key={index}
+            href={link.url}
+            target={link.internal ? undefined : '_blank'}
+            rel={link.internal ? undefined : 'noopener noreferrer'}
+            className={styles.card}
+          >
             <h2>{link.title} &rarr;</h2>
             <p>{link.description}</p>
           </a>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -16,6 +16,9 @@ const Navbar = () => {
           <Link href="/contracts">Smart Contracts</Link>
         </li>
         <li>
+          <Link href="/nft">NFT</Link>
+        </li>
+        <li>
           <Link href="/docs">Docs</Link>
         </li>
         <li>

--- a/src/components/nft/Flow.tsx
+++ b/src/components/nft/Flow.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styles from '@/styles/nft.module.css';
+
+export type FlowStep = {
+  title: string;
+  detail: string;
+  branch?: boolean;
+};
+
+const Flow = ({ steps }: { steps: FlowStep[] }) => {
+  return (
+    <div className={styles.flow}>
+      {steps.map((step, index) => (
+        <React.Fragment key={index}>
+          {index > 0 && (
+            <div className={styles.flowArrow} aria-hidden="true">
+              ↓
+            </div>
+          )}
+          <div className={step.branch ? `${styles.flowStep} ${styles.flowBranch}` : styles.flowStep}>
+            <h4>{step.title}</h4>
+            <p>{step.detail}</p>
+          </div>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default Flow;

--- a/src/components/nft/NftBuyers.tsx
+++ b/src/components/nft/NftBuyers.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import styles from '@/styles/nft.module.css';
+import PersonaNav from './PersonaNav';
+import Flow from './Flow';
+
+const buyFlow = [
+  {
+    title: '1 · You see a listing',
+    detail:
+      'Price, currency, and the token’s royalty terms are on-chain state — what your wallet shows can be checked against the chain, not taken on faith from a website.',
+  },
+  {
+    title: '2 · You sign exactly two things',
+    detail:
+      'A transfer of the exact listed price into the sale’s escrow, and the purchase itself naming your account. That is your entire exposure — there is nothing else to sign.',
+  },
+  {
+    title: '3 · The contract settles',
+    detail:
+      'In one step: royalty to the creator, fee to the marketplace, remainder to the seller, token to you. The contract asserts the amounts add up exactly before anything moves.',
+  },
+  {
+    title: '4 · You own it',
+    detail:
+      'Ownership is a ledger row guarded by your key — not a marketplace database entry. Any conforming marketplace, wallet, or indexer sees the same fact.',
+  },
+];
+
+const NftBuyers = () => {
+  return (
+    <div className={styles.page}>
+      <h1>For buyers</h1>
+      <p className={styles.lede}>
+        You authorize the exact price and nothing else. A compromised website, a hostile seller, or
+        a malicious marketplace cannot make you overpay, redirect your payment, or hand you a fake.
+      </p>
+
+      <PersonaNav current="/nft/buyers" />
+
+      <section>
+        <h2>What buying looks like</h2>
+        <Flow steps={buyFlow} />
+      </section>
+
+      <section>
+        <h2>Why you can&apos;t be cheated</h2>
+        <ul>
+          <li>
+            <strong>Your signature is scoped.</strong> The payment you sign is for the exact listed
+            price, to a specific escrow, for this one sale. It cannot be replayed, redirected, or
+            stretched — if anything about the sale doesn&apos;t match, the whole transaction aborts
+            and your money never leaves.
+          </li>
+          <li>
+            <strong>The economics were fixed before you arrived.</strong> Price, royalty, and fee
+            were bound to the listing when the seller signed it. Nothing in <em>your</em>{' '}
+            transaction can change them — which also means nothing in a manipulated frontend can.
+          </li>
+          <li>
+            <strong>The token is what it says it is.</strong> A token&apos;s id is derived from its
+            creator&apos;s identity — a counterfeit &quot;same&quot; token cannot exist, on this
+            chain or any other. Provenance is in the id, not in a checkmark.
+          </li>
+          <li>
+            <strong>Settlement is all-or-nothing.</strong> One atomic step pays everyone and
+            transfers the token. There is no state where your payment is gone and the token
+            isn&apos;t yours.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Bidding in auctions</h2>
+        <ul>
+          <li>
+            <strong>Your bid is escrowed by the contract</strong>, not by the marketplace. If
+            someone outbids you, your full bid comes back automatically — no claims process.
+          </li>
+          <li>
+            <strong>Winning is checked on-chain.</strong> Settlement validates the winner and the
+            winning amount against the auction&apos;s own recorded state; a &quot;discovered
+            price&quot; that doesn&apos;t match the real bidding history is rejected.
+          </li>
+          <li>
+            <strong>Declining-price auctions</strong> sell to the first acceptance at the current
+            scheduled price — you can compute that price yourself from the on-chain curve before
+            you commit.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>What ownership gets you</h2>
+        <p>
+          Your token is a row in a public ledger, guarded by your key. You can hold it, gift it (if
+          the creator allowed free transfers), list it on any conforming marketplace, or move it to
+          another chain in the same network — its rules travel with it. If the token is
+          &quot;sale-only&quot;, that is the creator&apos;s enforced choice, visible before you buy:
+          it can change hands only through a sale that pays the royalty.
+        </p>
+        <div className={styles.callout}>
+          <p>
+            <strong>One habit worth keeping:</strong> before a large purchase, verify the
+            marketplace&apos;s contract hash against the published tables in the{' '}
+            <a
+              href="https://github.com/Pact-Community-Organization/pact-contract-catalog"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              contract catalog
+            </a>
+            . One <code>describe-module</code> call tells you whether you are talking to the real,
+            audited code — that is the point of an on-chain standard.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default NftBuyers;

--- a/src/components/nft/NftCreators.tsx
+++ b/src/components/nft/NftCreators.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import styles from '@/styles/nft.module.css';
+import PersonaNav from './PersonaNav';
+import Flow from './Flow';
+
+const mintFlow = [
+  {
+    title: '1 · Choose the token’s rules (policies)',
+    detail:
+      'Royalty percentage and payout account, one-of-one or edition, collection membership, transfer rules, whether the artwork link can ever change. These choices are permanent.',
+  },
+  {
+    title: '2 · Create the token',
+    detail:
+      'The ledger derives the token’s id from your guard (your on-chain identity) and the token’s details. Only you can create it, and it can only ever exist once.',
+  },
+  {
+    title: '3 · Mint',
+    detail: 'The token is written to its owner — you, or a buyer if the marketplace mints on sale.',
+  },
+  {
+    title: '4 · It lives its life',
+    detail:
+      'Sold on any marketplace, auctioned, moved between chains — your royalty terms travel with it and are enforced at every sale, everywhere, forever.',
+  },
+];
+
+const NftCreators = () => {
+  return (
+    <div className={styles.page}>
+      <h1>For creators</h1>
+      <p className={styles.lede}>
+        You decide a token&apos;s rules once, at creation — and the chain enforces them for the rest
+        of the token&apos;s life. No marketplace can opt out of your royalty, and nobody can mint a
+        token pretending to be you.
+      </p>
+
+      <PersonaNav current="/nft/creators" />
+
+      <section>
+        <h2>From idea to minted token</h2>
+        <Flow steps={mintFlow} />
+      </section>
+
+      <section>
+        <h2>Your identity is the anchor</h2>
+        <p>
+          Every token id is <strong>derived from its creator&apos;s guard</strong> — the
+          cryptographic identity that only you control. Two things follow:
+        </p>
+        <ul>
+          <li>
+            <strong>Forgery is impossible.</strong> Nobody can create a token whose id claims your
+            authorship — the creation would fail because they cannot satisfy your guard.
+          </li>
+          <li>
+            <strong>Double-minting is impossible.</strong> One id, one row, forever. The same token
+            cannot be created again — on the same chain or any other.
+          </li>
+        </ul>
+        <p>
+          Collectors do not need to trust a marketplace&apos;s word about who made a token: the id
+          itself proves it.
+        </p>
+      </section>
+
+      <section>
+        <h2>The policy menu — your rules, made permanent</h2>
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Policy</th>
+                <th>What it gives you</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <strong>Royalty</strong>
+                </td>
+                <td>
+                  A percentage of <em>every</em> sale (up to 50%), paid to the account you name, on
+                  the chain where the sale happens. Enforced by the settlement engine itself — a
+                  marketplace cannot skip it, and an auction cannot dodge it. Prices that would
+                  round your royalty down to zero are rejected outright.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Sale-only</strong> (royalty opt-in)
+                </td>
+                <td>
+                  The token can change owners <em>only through a sale</em>. Free transfers are
+                  rejected, and a cross-chain move cannot change the owner — so there is no
+                  royalty-free way out. Choose it for work where the royalty is the point; skip it
+                  if you want owners to be able to gift freely.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>One-of-one</strong>
+                </td>
+                <td>A strict single edition: supply is one, minted once, ever.</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Collection</strong>
+                </td>
+                <td>
+                  Membership in an operator-gated collection with an optional size cap — provable
+                  scarcity for a series.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Operation guards</strong>
+                </td>
+                <td>
+                  Fine-grained control: separate guards for minting, burning, selling, and
+                  transferring — for tokens that need custom authorization rules.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Artwork link (URI) rules</strong>
+                </td>
+                <td>
+                  By default a token&apos;s metadata link is <strong>immutable</strong>. You can
+                  attach a policy that allows guarded updates (you keep a key), or one that vetoes
+                  updates unconditionally — a veto always wins over a permit.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className={styles.callout}>
+          <p>
+            <strong>Permanence works in your favor.</strong> The policy set is fixed when the token
+            is created and canonically ordered — it cannot be extended, re-ordered, or composed away
+            later. A rule you set at mint cannot be undone by a future marketplace, upgrade, or
+            clever combination of policies.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Your royalty travels</h2>
+        <p>
+          When a token moves to another chain, every policy packs its state — your royalty terms,
+          the guards, the edition marker — into a <strong>passport</strong> that travels with the
+          token and re-binds on arrival. A token that sells on another chain still pays you there.
+          The royalty account you name should be one you control on every chain (a standard{' '}
+          <code>k:</code> account works everywhere; the settlement creates it on a chain the first
+          time a royalty arrives there).
+        </p>
+      </section>
+
+      <section>
+        <h2>What creators should double-check before minting</h2>
+        <ol>
+          <li>
+            <strong>The royalty account and percentage</strong> — both are permanent for that token.
+          </li>
+          <li>
+            <strong>Sale-only or freely transferable</strong> — permanent, and it changes what your
+            collectors can do (gifts, private moves).
+          </li>
+          <li>
+            <strong>The artwork link stance</strong> — if you attach no URI policy, the link is
+            frozen forever; if your art is meant to evolve, attach the guarded-update policy at
+            creation.
+          </li>
+        </ol>
+      </section>
+    </div>
+  );
+};
+
+export default NftCreators;

--- a/src/components/nft/NftMarketplaces.tsx
+++ b/src/components/nft/NftMarketplaces.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import styles from '@/styles/nft.module.css';
+import PersonaNav from './PersonaNav';
+import Flow from './Flow';
+
+const CATALOG = 'https://github.com/Pact-Community-Organization/pact-contract-catalog';
+
+const frameworkFlow = [
+  {
+    title: '1 · Create your revenue account',
+    detail:
+      'A principal account in the sale currency (e.g. coin). This is where your fees land. At listing time, always fetch its live guard from the chain — never hand-build one.',
+  },
+  {
+    title: '2 · Build the listing flow',
+    detail:
+      'Your frontend assembles the seller’s offer with the quote: price, seller payout, and YOUR fee account + rate (up to 10%; charge less as policy). The seller signs; economics bind in state.',
+  },
+  {
+    title: '3 · Build the buy flow',
+    detail:
+      'The buyer signs a transfer of the exact price into escrow plus the purchase continuation. The settlement engine pays your fee automatically — no marketplace code in the loop.',
+  },
+  {
+    title: '4 · Optional: host auctions',
+    detail:
+      'Point listings at the governance-registered auction contracts and run the settlement crank as a service once auctions end (anyone may settle; your crank makes it a product).',
+  },
+  {
+    title: '5 · Index the events',
+    detail:
+      'QUOTE and SETTLED from the settlement engine; TOKEN, SALE, TRANSFER, RECONCILE, SUPPLY from the ledger; ROYALTY from the royalty policy; AUCTION-CREATED / BID / BID-REFUNDED from the auctions. That is the complete data surface a catalog UI needs.',
+  },
+];
+
+const standaloneFlow = [
+  {
+    title: '1 · Start from the reference implementation',
+    detail:
+      'Copy royalty-sale from the catalog library (MIT, audited) and adapt namespace, keysets, and fee policy.',
+  },
+  {
+    title: '2 · Implement the standard, fully qualified',
+    detail:
+      'Your module implements nft-asset-v1 / nft-market-v1 (and nft-xchain-v1 if you support chain moves) from the PCO namespace. A private copy of the interfaces is a different type — it does not conform.',
+  },
+  {
+    title: '3 · Pass the conformance suite',
+    detail:
+      'The suite drives your module through an interface reference with adversarial vectors — the same bar every conforming marketplace clears. Passing it is what “compatible” means.',
+  },
+  {
+    title: '4 · Validate on devnet, then deploy',
+    detail:
+      'One class of node-side bug is invisible in the REPL — always run a devnet pass. Then deploy your module only; the interfaces are already published on-chain.',
+  },
+];
+
+const NftMarketplaces = () => {
+  return (
+    <div className={styles.page}>
+      <h1>Build your own marketplace</h1>
+      <p className={styles.lede}>
+        A business can open an NFT market on Kadena in two ways — and the most common one requires
+        deploying no smart contract at all. Both rest on PCO-published, frozen on-chain interfaces,
+        so what you build is compatible with the rest of the ecosystem from day one.
+      </p>
+
+      <PersonaNav current="/nft/marketplaces" />
+
+      <section>
+        <h2>Choosing your track</h2>
+        <div className={styles.archGrid}>
+          <div className={styles.archBox}>
+            <h3>Framework marketplace — deploy nothing</h3>
+            <p>
+              Tokens live in the shared ledger; the framework&apos;s settlement engine runs every
+              sale. Your marketplace is:
+            </p>
+            <ul>
+              <li>a <strong>fee identity</strong> named in every seller-signed listing,</li>
+              <li>optionally an <strong>auction venue</strong> with a settlement crank,</li>
+              <li>a <strong>frontend</strong> that builds the transactions.</li>
+            </ul>
+          </div>
+          <div className={styles.archBox}>
+            <h3>Standalone marketplace — deploy one module</h3>
+            <p>
+              Your own module, your own ledger and custody, your own rules — conforming to the
+              interface standard so wallets, indexers, and aggregators treat you like every other
+              marketplace.
+            </p>
+            <ul>
+              <li>Full control of custody and features</li>
+              <li>Audited reference implementation to start from</li>
+              <li>Conformance suite as your acceptance bar</li>
+            </ul>
+          </div>
+        </div>
+        <p>
+          Pick the framework track if your product is the storefront. Pick the standalone track if
+          your product needs its own contract logic. Nothing stops a company from doing both.
+        </p>
+      </section>
+
+      <section>
+        <h2>Track 1 · A marketplace on the framework</h2>
+        <Flow steps={frameworkFlow} />
+        <div className={styles.callout}>
+          <p>
+            <strong>You write no Pact and touch no settlement math.</strong> Conservation
+            (money-in = money-out), creator royalties, and escrow discipline are the
+            framework&apos;s job — enforced identically for every marketplace. Your fee arrives at
+            your account on the chain where each sale happens.
+          </p>
+          <p>
+            The step-by-step companion with the exact quote fields lives in the catalog:{' '}
+            <a href={`${CATALOG}/blob/main/contracts/nft/QUICKSTART.md`} target="_blank" rel="noopener noreferrer">
+              marketplace quickstart
+            </a>{' '}
+            · the field-by-field integration surface is section 10 of the{' '}
+            <a href={`${CATALOG}/blob/main/contracts/nft/TECHNICAL.md`} target="_blank" rel="noopener noreferrer">
+              technical reference
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Track 2 · A standalone marketplace on the standard</h2>
+        <Flow steps={standaloneFlow} />
+        <p>
+          The{' '}
+          <a href={`${CATALOG}/blob/main/contracts/standards/SPEC.md`} target="_blank" rel="noopener noreferrer">
+            specification
+          </a>{' '}
+          defines the behavior your module must honor beyond the signatures — fail-closed inputs,
+          one conservation-asserted settlement, on-chain economics, explicit sale-only royalty
+          protection, and royalty-safe cross-chain moves. The{' '}
+          <a href={`${CATALOG}/blob/main/contracts/standards/conformance/README.md`} target="_blank" rel="noopener noreferrer">
+            conformance guide
+          </a>{' '}
+          shows how to run the suite against your module.
+        </p>
+      </section>
+
+      <section>
+        <h2>What you still build yourself</h2>
+        <p>
+          On either track, the on-chain layer does not ship a frontend, an indexer, wallet
+          integration, or a minting UI — those are your product. The catalog&apos;s devnet
+          campaigns are working end-to-end references for every transaction your frontend must
+          build, including auction settlement by a third-party crank.
+        </p>
+      </section>
+
+      <section>
+        <h2>Why build on this instead of rolling your own</h2>
+        <ul>
+          <li>
+            <strong>Trust you don&apos;t have to earn alone.</strong> Sellers and buyers get the
+            standard&apos;s guarantees — checked settlement, unforgeable identity, enforced
+            royalties — from your first day, verifiable on-chain with one{' '}
+            <code>describe-module</code> call.
+          </li>
+          <li>
+            <strong>Ecosystem compatibility.</strong> Conforming marketplaces share wallets,
+            indexers, and aggregators; framework tokens listed with you can have been minted
+            anywhere in the ecosystem.
+          </li>
+          <li>
+            <strong>Creator alignment.</strong> Royalty enforcement is structural, not a policy
+            page — the creators most worth hosting choose venues where their cut is real.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default NftMarketplaces;

--- a/src/components/nft/NftOverview.tsx
+++ b/src/components/nft/NftOverview.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import Link from 'next/link';
+import styles from '@/styles/nft.module.css';
+import PersonaNav from './PersonaNav';
+
+const CATALOG = 'https://github.com/Pact-Community-Organization/pact-contract-catalog';
+
+const personas = [
+  {
+    href: '/nft/creators',
+    title: 'Creators',
+    description:
+      'Mint NFTs whose royalties are enforced by the chain itself — on every marketplace, on every chain, forever.',
+  },
+  {
+    href: '/nft/sellers',
+    title: 'Sellers',
+    description:
+      'List at a fixed price or run an auction. The economics you sign are the economics that settle — nobody can change them after you list.',
+  },
+  {
+    href: '/nft/buyers',
+    title: 'Buyers',
+    description:
+      'You sign the exact price and nothing else. The contract splits the payment and proves the math on every sale.',
+  },
+  {
+    href: '/nft/marketplaces',
+    title: 'Build a marketplace',
+    description:
+      'Launch your own NFT market — usually without deploying a single contract. Your fee is paid by the settlement engine itself.',
+  },
+];
+
+const NftOverview = () => {
+  return (
+    <div className={styles.page}>
+      <h1>NFTs on Pact</h1>
+      <p className={styles.lede}>
+        The PCO publishes an open NFT standard and a complete, audited NFT framework for the Kadena
+        chainweb — built so that creators keep their royalties, buyers cannot be cheated, and any
+        business can open a marketplace. This is the documentation for all of it.
+      </p>
+
+      <PersonaNav current="/nft" />
+
+      <section>
+        <h2>Two building blocks</h2>
+        <div className={styles.archGrid}>
+          <div className={styles.archBox}>
+            <h3>The interface standard v1</h3>
+            <p>
+              Three frozen on-chain interfaces (<code>nft-asset-v1</code>, <code>nft-market-v1</code>,{' '}
+              <code>nft-xchain-v1</code>) plus a normative specification. Marketplaces that implement
+              them are <strong>compatible</strong>: one wallet, one indexer, one aggregator works
+              across all of them.
+            </p>
+            <ul>
+              <li>For teams building standalone marketplace modules</li>
+              <li>Runnable conformance suite with adversarial tests</li>
+              <li>Audited MIT reference implementation to copy</li>
+            </ul>
+          </div>
+          <div className={styles.archBox}>
+            <h3>
+              The <code>nft</code> framework
+            </h3>
+            <p>
+              A shared-ledger NFT ecosystem: one hardened ledger anchors every token, one settlement
+              engine pays every sale, and composable policies carry each token&apos;s rules — royalties,
+              guards, editions, collections — with it wherever it goes.
+            </p>
+            <ul>
+              <li>Marketplaces need no contract of their own</li>
+              <li>Auctions built in (ascending and declining-price)</li>
+              <li>Tokens move between chains, rules travel along</li>
+            </ul>
+          </div>
+          <div className={`${styles.archBox} ${styles.archBase}`}>
+            <h3>One owner: the community</h3>
+            <p>
+              Both are published on-chain by the PCO in a single namespace per network, and both are
+              open source in the{' '}
+              <a href={CATALOG} target="_blank" rel="noopener noreferrer">
+                contract catalog
+              </a>
+              . Deployed interfaces cannot be upgraded — what is published is the standard,
+              permanently.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>The promises the code makes</h2>
+        <ul>
+          <li>
+            <strong>Nothing fails open.</strong> Every guard and account is required and validated —
+            a malformed input aborts, it never degrades to &quot;anyone can transfer&quot;.
+          </li>
+          <li>
+            <strong>One settlement, with the math checked.</strong> Every sale settles in a single
+            step that asserts <code>money in = money out</code> to the currency&apos;s full precision.
+            No stacked hook can skim.
+          </li>
+          <li>
+            <strong>Economics live on-chain, never in the buy transaction.</strong> Price, royalty,
+            and fees bind when the seller signs the listing. Nothing a buyer (or a malicious
+            frontend) sends can change them.
+          </li>
+          <li>
+            <strong>Royalties are real.</strong> A creator&apos;s cut is enforced at settlement — on
+            every marketplace, through every auction, and across chain moves. There is no
+            royalty-free exit unless the creator allowed one.
+          </li>
+          <li>
+            <strong>Identity cannot be forged.</strong> A token&apos;s id is derived from its
+            creator&apos;s guard: nobody can mint a token that claims to be someone else&apos;s, and
+            nothing can be minted twice.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Pick your path</h2>
+        <div className={styles.cardGrid}>
+          {personas.map((persona) => (
+            <Link key={persona.href} href={persona.href} className={styles.card}>
+              <h3>{persona.title} →</h3>
+              <p>{persona.description}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2>Deployment status</h2>
+        <div className={styles.callout}>
+          <p>
+            The standard and framework are complete, audited, and open source today. They were
+            published to the community testnet across all 20 chains in July 2026; a network-wide
+            reset later removed everything on that testnet, and re-publication is pending the
+            network&apos;s return. Because the namespace and module hashes are deterministic, the
+            catalog records the expected values — when re-published, anyone can verify every module
+            with <code>describe-module</code> against those tables.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Go deeper</h2>
+        <div className={styles.cardGrid}>
+          <a
+            className={styles.card}
+            href={`${CATALOG}/blob/main/contracts/standards/SPEC.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h3>The specification →</h3>
+            <p>The normative rules (S1–S6) every conforming marketplace must obey, and why each one exists.</p>
+          </a>
+          <a
+            className={styles.card}
+            href={`${CATALOG}/blob/main/contracts/nft/QUICKSTART.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h3>Marketplace quickstart →</h3>
+            <p>Launch your own market, step by step — the companion to the Build-a-marketplace page here.</p>
+          </a>
+          <a
+            className={styles.card}
+            href={`${CATALOG}/blob/main/contracts/nft/TECHNICAL.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h3>Technical reference →</h3>
+            <p>Every mechanism down to the code: identity, policies, settlement, auctions, cross-chain.</p>
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default NftOverview;

--- a/src/components/nft/NftSellers.tsx
+++ b/src/components/nft/NftSellers.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import styles from '@/styles/nft.module.css';
+import PersonaNav from './PersonaNav';
+import Flow from './Flow';
+
+const listFlow = [
+  {
+    title: '1 · You sign the listing (the “quote”)',
+    detail:
+      'Price, currency, your payout account, and the marketplace’s fee are written into chain state, under your signature. This is the sale’s complete economics.',
+  },
+  {
+    title: '2 · The token is held by the sale',
+    detail:
+      'While listed, the token cannot be quietly transferred or moved to another chain. You can withdraw (delist) any time before it sells.',
+  },
+  {
+    title: '3 · A buyer pays the exact price into escrow',
+    detail:
+      'The buyer’s payment can only be the listed price — not a penny more or less reaches settlement.',
+  },
+  {
+    title: '4 · One settlement pays everyone',
+    detail:
+      'Creator royalty, marketplace fee, and your remainder are paid in a single step that proves money-in equals money-out. Your proceeds arrive at the payout account you named.',
+  },
+];
+
+const NftSellers = () => {
+  return (
+    <div className={styles.page}>
+      <h1>For sellers</h1>
+      <p className={styles.lede}>
+        The deal you sign is the deal that settles. Once you list, no marketplace admin, no buyer,
+        and no frontend can change the price, the fees, or where your money goes.
+      </p>
+
+      <PersonaNav current="/nft/sellers" />
+
+      <section>
+        <h2>How a fixed-price sale works</h2>
+        <Flow steps={listFlow} />
+        <div className={styles.callout}>
+          <p>
+            <strong>Why this matters:</strong> on some NFT platforms, fees and payees have been read
+            from the <em>buyer&apos;s</em> transaction — meaning a hostile buyer could zero the fee,
+            or a compromised frontend could redirect proceeds. Here, everything that moves money is
+            bound to the listing you signed and read back from chain state at settlement. That rule
+            is part of the standard itself.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>What you get, exactly</h2>
+        <p>A worked example — you list at 100 KDA on a marketplace charging 2.5%, for a token with a 10% creator royalty:</p>
+        <div className={styles.split}>
+          <div className={styles.splitIn}>
+            <h4>Buyer pays 100 KDA into escrow</h4>
+          </div>
+          <div className={styles.splitArrows} aria-hidden="true">
+            ↓
+          </div>
+          <div className={styles.splitOut}>
+            <div className={styles.splitLeg}>
+              <h4>10 KDA</h4>
+              <p>creator royalty</p>
+            </div>
+            <div className={styles.splitLeg}>
+              <h4>2.5 KDA</h4>
+              <p>marketplace fee</p>
+            </div>
+            <div className={styles.splitLeg}>
+              <h4>87.5 KDA</h4>
+              <p>you, the seller</p>
+            </div>
+          </div>
+          <p className={styles.splitNote}>
+            The contract asserts 10 + 2.5 + 87.5 = 100 to twelve decimal places — every sale, every
+            time.
+          </p>
+        </div>
+        <p>
+          The royalty percentage is fixed on the token (set by its creator at mint); the fee is the
+          marketplace&apos;s rate at the moment you list. Both are visible before you sign.
+        </p>
+      </section>
+
+      <section>
+        <h2>Auctions</h2>
+        <p>
+          Instead of a fixed price, your listing can hand price discovery to an{' '}
+          <strong>auction contract</strong>. Two are built in:
+        </p>
+        <ul>
+          <li>
+            <strong>Ascending (conventional) auction</strong> — you set a reserve price, a minimum
+            bid increment, and a schedule. Bids are held in escrow by the contract; every outbid
+            bidder is refunded in full, automatically. When the auction ends, anyone can trigger
+            settlement — the winning bid becomes the sale price.
+          </li>
+          <li>
+            <strong>Declining-price (dutch) auction</strong> — you set a start price, a floor, and a
+            step interval. The price walks down on schedule; the first buyer to accept wins at the
+            current price, never below your floor.
+          </li>
+        </ul>
+        <p>
+          Royalty and marketplace fee are carved from the <em>final discovered price</em> — an
+          auction is not a way around anyone&apos;s cut. Only auction contracts registered by the
+          framework&apos;s governance can be used, so a listing can never point at a fake auction
+          that steals the token.
+        </p>
+      </section>
+
+      <section>
+        <h2>Delisting and safety</h2>
+        <ul>
+          <li>
+            <strong>You can withdraw an unsold listing at any time</strong> — the token returns to
+            your full control. Nobody else can delist for you (or buy after you delist).
+          </li>
+          <li>
+            <strong>A listed token cannot leave the chain.</strong> Cross-chain moves are blocked
+            while a listing is live, so a sale you signed can never be stranded.
+          </li>
+          <li>
+            <strong>Repricing means relisting.</strong> Withdrawing and listing again is the only
+            way to change the price — there is no in-place edit a buyer could race against.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default NftSellers;

--- a/src/components/nft/PersonaNav.tsx
+++ b/src/components/nft/PersonaNav.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Link from 'next/link';
+import styles from '@/styles/nft.module.css';
+
+const pages = [
+  { href: '/nft', label: 'Overview' },
+  { href: '/nft/creators', label: 'Creators' },
+  { href: '/nft/sellers', label: 'Sellers' },
+  { href: '/nft/buyers', label: 'Buyers' },
+  { href: '/nft/marketplaces', label: 'Build a marketplace' },
+];
+
+const PersonaNav = ({ current }: { current: string }) => {
+  return (
+    <nav className={styles.personaNav} aria-label="NFT documentation pages">
+      {pages.map((page) => (
+        <Link
+          key={page.href}
+          href={page.href}
+          className={page.href === current ? styles.active : undefined}
+        >
+          {page.label}
+        </Link>
+      ))}
+    </nav>
+  );
+};
+
+export default PersonaNav;

--- a/src/styles/nft.module.css
+++ b/src/styles/nft.module.css
@@ -1,0 +1,328 @@
+.container {
+  padding: 2rem;
+}
+
+.page {
+  max-width: 900px;
+  margin: 3rem auto;
+  padding: 0 1rem 4rem;
+}
+
+.page h1 {
+  font-size: 2.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.lede {
+  font-size: 1.2rem;
+  color: var(--text-secondary);
+  margin-bottom: 2.5rem;
+}
+
+.page section {
+  margin-bottom: 2.75rem;
+}
+
+.page h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.page h3 {
+  font-size: 1.15rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.page p {
+  margin-bottom: 1rem;
+}
+
+.page ul,
+.page ol {
+  margin: 0 0 1rem 1.4rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.page li {
+  margin-bottom: 0.5rem;
+}
+
+.page li strong,
+.page p strong {
+  color: var(--text-primary);
+}
+
+.page code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.1rem 0.4rem;
+  color: var(--primary);
+  overflow-wrap: anywhere;
+}
+
+/* ---- callouts ---- */
+
+.callout {
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--primary);
+  border-radius: var(--border-radius);
+  padding: 1.25rem 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.callout p {
+  margin: 0;
+}
+
+.callout p + p {
+  margin-top: 0.75rem;
+}
+
+/* ---- persona sub-navigation ---- */
+
+.personaNav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.personaNav a {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  transition: border-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.personaNav a:hover {
+  border-color: var(--primary);
+  color: var(--text-primary);
+}
+
+.personaNav a.active {
+  border-color: var(--primary);
+  color: var(--text-primary);
+  background: rgba(163, 147, 255, 0.1);
+}
+
+/* ---- flow diagram ---- */
+
+.flow {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 1.5rem 0;
+}
+
+.flowStep {
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: 1rem 1.25rem;
+}
+
+.flowStep h4 {
+  font-size: 1rem;
+  color: var(--text-primary);
+  margin-bottom: 0.3rem;
+}
+
+.flowStep p {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.flowArrow {
+  align-self: center;
+  color: var(--primary);
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 0.35rem 0;
+}
+
+.flowBranch {
+  border-style: dashed;
+}
+
+/* ---- settlement split diagram ---- */
+
+.split {
+  margin: 1.5rem 0;
+}
+
+.splitIn {
+  background: var(--surface);
+  border: 1px solid var(--primary);
+  border-radius: var(--border-radius);
+  padding: 1rem 1.25rem;
+  text-align: center;
+}
+
+.splitIn h4 {
+  color: var(--text-primary);
+  font-size: 1rem;
+  margin: 0;
+}
+
+.splitIn p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+}
+
+.splitArrows {
+  text-align: center;
+  color: var(--primary);
+  padding: 0.35rem 0;
+  font-size: 1.2rem;
+}
+
+.splitOut {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.splitLeg {
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: 0.9rem 1rem;
+  text-align: center;
+}
+
+.splitLeg h4 {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  margin-bottom: 0.2rem;
+}
+
+.splitLeg p {
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.splitNote {
+  text-align: center;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  margin-top: 0.75rem;
+  font-style: italic;
+}
+
+/* ---- persona / link cards ---- */
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+  margin: 1.5rem 0;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  padding: 1.5rem;
+  border-radius: var(--border-radius);
+  text-decoration: none;
+  transition: transform 0.2s ease-in-out, border-color 0.2s ease-in-out;
+  display: block;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary);
+}
+
+.card h3 {
+  font-size: 1.2rem;
+  margin: 0 0 0.5rem;
+  color: var(--text-primary);
+}
+
+.card p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+/* ---- two-column architecture diagram ---- */
+
+.archGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin: 1.5rem 0;
+}
+
+@media (max-width: 700px) {
+  .archGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.archBox {
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: 1.25rem 1.5rem;
+}
+
+.archBox h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.archBox p {
+  font-size: 0.92rem;
+  margin-bottom: 0.75rem;
+}
+
+.archBox ul {
+  margin: 0 0 0 1.2rem;
+  font-size: 0.9rem;
+}
+
+.archBase {
+  grid-column: 1 / -1;
+  text-align: center;
+  border-color: var(--primary);
+}
+
+/* ---- simple table ---- */
+
+.tableWrap {
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--border-color);
+  padding: 0.6rem 0.9rem;
+  text-align: left;
+  color: var(--text-secondary);
+  vertical-align: top;
+}
+
+.table th {
+  color: var(--text-primary);
+  background: var(--surface);
+}


### PR DESCRIPTION
Closes #85.

Adds a full NFT documentation section for the PCO NFT ecosystem (the Kadena NFT interface standard v1 + the `nft` framework), written for every audience and matching the site's existing dark-theme CSS-module idiom.

## New routes

| Route | Audience |
|---|---|
| `/nft` | Overview: the two building blocks (standard + framework), the code's guarantees, persona cards, deployment status, deep links to SPEC / QUICKSTART / TECHNICAL in the contract catalog |
| `/nft/creators` | Minting: token identity (forgery/double-mint impossible), the policy menu (royalty, sale-only, 1/1, collections, guards, URI rules), royalty passports across chains, pre-mint checklist |
| `/nft/sellers` | Fixed-price listing flow, worked settlement split (100 → 10 / 2.5 / 87.5), both auction types, delisting & safety |
| `/nft/buyers` | What a buyer signs and why they cannot be cheated, atomic settlement, auction bidding (escrowed bids, automatic refunds), hash verification habit |
| `/nft/marketplaces` | The two tracks for companies — framework fee-identity (deploy nothing) vs standalone standard implementation — step by step, conformance, what you still build yourself |

## Visual aids

Reusable `Flow` component (step diagrams), settlement-split diagram, two-column architecture map, persona pill navigation — all pure CSS on the site's design tokens, no new dependencies.

## Wiring

- Navbar: new **NFT** link
- Docs hub: new internal card linking to `/nft`

## Evidence

- `npm run build`: ✓ 13/13 static pages including all 5 new routes
- `npm run lint`: no findings in the new files (the one repo error is pre-existing in `src/components/community/Community.tsx`)
- Rendered pages verified in a browser (dark theme, flow diagrams, tables, active-state nav)

## Notes

- Content is sourced from the canonical catalog docs (SPEC.md, QUICKSTART.md, TECHNICAL.md) and stays truthful about on-chain status: published July 2026, removed by the testnet-wide reset, re-publication pending.
- Off-scope but observed: `/contracts` still renders placeholder sample data (issue #37).