### PR TITLE
fix: drop 404ing placeholder background image from community CTA

### DIFF
--- a/src/styles/community-cta.module.css
+++ b/src/styles/community-cta.module.css
@@ -1,9 +1,7 @@
 .communityCTA {
   padding: 6rem 2rem;
   text-align: center;
-  background: linear-gradient(rgba(15, 13, 26, 0.9), rgba(15, 13, 26, 0.9)), url('/path-to-abstract-background.png');
-  background-size: cover;
-  background-position: center;
+  background: linear-gradient(rgba(15, 13, 26, 0.9), rgba(15, 13, 26, 0.9));
   border-top: 1px solid var(--border-color);
   border-bottom: 1px solid var(--border-color);
 }


### PR DESCRIPTION
The community CTA section referenced a literal placeholder path (/path-to-abstract-background.png) that never existed — the only console error on the live site. The near-opaque gradient renders identically without it. Refs #89.