### PR TITLE
feat: surface the fixed-supply token templates on /contracts + roadmap sync

### DIFF
--- a/src/components/contracts/ContractCatalog.tsx
+++ b/src/components/contracts/ContractCatalog.tsx
@@ -14,6 +14,22 @@ const contracts = [
     version: '0.2.0',
   },
   {
+    name: 'Token (fixed supply)',
+    description:
+      'A frozen, non-upgradeable fungible-v2 token: one-shot exact-distribution mint, self-burn only, no admin surface — immutability as the product.',
+    repository: `${CATALOG}/token-fixed-supply`,
+    auditState: 'Self-reviewed',
+    version: '1.0.0',
+  },
+  {
+    name: 'Token (fixed supply + advisory governance)',
+    description:
+      'The fixed-supply token plus advisory live-vote governance: vote weight = current balance, balance decreases release recorded votes, permanent on-chain tallies — votes execute nothing.',
+    repository: `${CATALOG}/token-fixed-supply-gov`,
+    auditState: 'Self-reviewed',
+    version: '1.0.0',
+  },
+  {
     name: 'Gas Station',
     description:
       'Drain-defended gas sponsorship: bounds and accounting against actual chain gas, never signer-supplied values, with a per-user on-chain allowlist.',

--- a/src/components/roadmap/Roadmap.tsx
+++ b/src/components/roadmap/Roadmap.tsx
@@ -6,12 +6,13 @@ const CATALOG = 'https://github.com/Pact-Community-Organization/pact-contract-ca
 
 const shipped = [
   {
-    title: 'Contract Library — nine security-reviewed templates',
+    title: 'Contract Library — eleven security-reviewed templates',
     body: (
       <>
-        Deployable templates for the foundations most projects need: fungible token, gas station,
-        multisig treasury, vesting, DAO voting, oracle feed, property lease, an NFT marketplace, and
-        a minimal starter. Every entry shipped through a blocking test suite, static analysis, and a
+        Deployable templates for the foundations most projects need: fungible token, fixed-supply
+        community tokens (plain, and with advisory live-vote governance), gas station, multisig
+        treasury, vesting, DAO voting, oracle feed, property lease, an NFT marketplace, and a
+        minimal starter. Every entry shipped through a blocking test suite, static analysis, and a
         documented adversarial review. <Link href="/contracts">Browse the catalog →</Link>
       </>
     ),


### PR DESCRIPTION
Closes #92.

Adds the two new catalog library templates to the contracts page and syncs the roadmap's shipped-library count (nine → eleven, fixed-supply community tokens named). Build + lint green; no other content touched (PCO-1's refreshed structure followed).

**Merge gate: after Pact-Community-Organization/pact-contract-catalog#51 (founder merges) — until then the two catalog links 404.** After merge, the Pages deploy publishes automatically; live verification (curl + browser link check on /contracts and /roadmap) is the follow-up step.