### PR TITLE
fix(wiki-sync): skip cleanly when the wiki repo does not exist

### DIFF
--- a/.github/workflows/sync-files-to-wiki.yml
+++ b/.github/workflows/sync-files-to-wiki.yml
@@ -23,13 +23,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Clone Wiki repository
+        id: clone
         run: |
-          # If the wiki repo does not exist, skip sync
+          # If the wiki repo does not exist (first page never created via the
+          # GitHub UI), SKIP the whole sync — exit 0 here only ends this step,
+          # so later steps must gate on the output below.
           set -e
-          git ls-remote "https://github.com/${{ github.repository }}.wiki.git" >/dev/null 2>&1 || { echo "No wiki repository found for ${GITHUB_REPOSITORY}; skipping sync."; exit 0; }
+          if ! git ls-remote "https://github.com/${{ github.repository }}.wiki.git" >/dev/null 2>&1; then
+            echo "No wiki repository found for ${GITHUB_REPOSITORY}; skipping sync."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git clone "https://github.com/${{ github.repository }}.wiki.git" wiki-repo
+          echo "exists=true" >> "$GITHUB_OUTPUT"
       
       - name: Copy content from wiki/ to Wiki repo
+        if: steps.clone.outputs.exists == 'true'
         run: |
           cd wiki-repo
           # Remove existing .md files
@@ -38,6 +47,7 @@ jobs:
           cp ../wiki/*.md ./
       
       - name: Commit and push changes to Wiki
+        if: steps.clone.outputs.exists == 'true'
         run: |
           cd wiki-repo
           git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The clone step's `exit 0` guard only ends that step; the next step then fails on `cd wiki-repo` (seen on run 30140118585). Gate the copy/push steps on a step output. Once the wiki's first page is created via the GitHub UI, the next push to `wiki/**` syncs automatically.