### PR TITLE
token page: real Ledger support (WebHID, code-split)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "website",
       "version": "0.1.0",
       "dependencies": {
+        "@ledgerhq/hw-transport-webhid": "^6.36.0",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0",
+        "@zondax/ledger-kadena": "^0.0.4",
+        "buffer": "^6.0.3",
         "lucide-react": "^0.577.0",
         "next": "16.2.10",
         "react": "19.2.7",
@@ -1023,6 +1026,63 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@ledgerhq/devices": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.16.0.tgz",
+      "integrity": "sha512-brXLPzkvGM3D5YNsWQ25P5G4SmWdSNBed9W8wKoOIRLGdRfvE+bg9mzFty0iZ+aRLBkLoXwX7xKIL9zUi6LBKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@ledgerhq/devices/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ledgerhq/errors": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.37.0.tgz",
+      "integrity": "sha512-T5yiKI5UX7ugeocdTF3TUsCIN2BH41Bio4ZeN410YFjFOf3es08n/5JyMzzKwzRgP0blG3HfBf7s7vJKqCSAeg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ledgerhq/hw-transport": {
+      "version": "6.35.5",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.5.tgz",
+      "integrity": "sha512-P4+wtLewLWgxPtIb90h5kjpzXVlC6f4IBQBmvowVFkInvZt34ffXkX7wa5KfMzu4l3cqCcpNSqtPSCMp+0vuqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.16.0",
+        "@ledgerhq/errors": "^6.37.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid": {
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.36.0.tgz",
+      "integrity": "sha512-1mKWm3LyGOgmaYlAiqbmaGoupOZHbj2Kow5sXLxKZzQa4kFvQuUdinYOWhs7T8hqJyAkz9WlHYyKM7aIs8kjNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.16.0",
+        "@ledgerhq/errors": "^6.37.0",
+        "@ledgerhq/hw-transport": "6.35.5",
+        "@ledgerhq/logs": "^6.17.0"
+      }
+    },
+    "node_modules/@ledgerhq/logs": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
+      "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2235,6 +2295,64 @@
         "win32"
       ]
     },
+    "node_modules/@zondax/ledger-js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@zondax/ledger-js/-/ledger-js-1.3.3.tgz",
+      "integrity": "sha512-naWfF5usVF53JDS8y7tTl4DpQep7SHm8JN1/SnS84MSI0Xh6UIUhZf7Js+p/zjiRHcjSt/WpeSwPhFouSI7J9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/hw-transport": "6.35.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@zondax/ledger-js/node_modules/@ledgerhq/devices": {
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.15.1.tgz",
+      "integrity": "sha512-o4XEHiwPytnZxYUnOC5JoHX5TPDJpeMXPfXjwhsXVJ9LAbahxQWzC37Iuzk8ZY/oC2yDptzqjs/qNP2y9D9vCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "rxjs": "7.8.2",
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@zondax/ledger-js/node_modules/@ledgerhq/hw-transport": {
+      "version": "6.35.4",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.4.tgz",
+      "integrity": "sha512-FMVxiniQp0pgSIEBX9CjXYBuIAH9BTm3OcrN+/2LqkB8QBeFZdiwmO4BeN9nc2aWspe9z6kxN3SuUyouedNokA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.15.1",
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@zondax/ledger-js/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@zondax/ledger-kadena": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@zondax/ledger-kadena/-/ledger-kadena-0.0.4.tgz",
+      "integrity": "sha512-XHHi4BasrKk7sGbtG+HZS1Ei/650aObeINL4jiqhqR3DekZ9U6oPTw7JbF/QN76yk1KPb2TWu6TOyC9ps6Iwuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@zondax/ledger-js": "^1.3.1",
+        "blakejs": "^1.2.1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2528,6 +2646,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
@@ -2539,6 +2677,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
@@ -2596,6 +2740,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/call-bind": {
@@ -3569,6 +3737,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4021,6 +4198,26 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5678,6 +5875,15 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ledgerhq/hw-transport-webhid": "^6.36.0",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.8.0",
+    "@zondax/ledger-kadena": "^0.0.4",
+    "buffer": "^6.0.3",
     "lucide-react": "^0.577.0",
     "next": "16.2.10",
     "react": "19.2.7",

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -156,19 +156,15 @@ export async function connectZelcore(): Promise<ConnectedWallet> {
 let ledgerApp: { transport?: { close?: () => Promise<void> }; getAddressAndPubKey: (p: string) => Promise<{ pubkey?: Uint8Array; publicKey?: Uint8Array }>; signHash: (p: string, h: string) => Promise<{ signature?: Uint8Array }> } | null = null;
 export async function connectLedger(): Promise<ConnectedWallet> {
   if (!('hid' in navigator)) throw new Error('This browser has no WebHID (use Chrome/Edge/Brave) — Ledger unavailable');
-  // Ledger libs are optional (heavy); load by name at runtime so the build
-  // doesn't require them. Absent → honest error (this DEVNET preview leads with
-  // the in-browser key and EckoWallet; Ledger is for the real launch build).
-  let TransportWebHID: { create: () => Promise<{ close?: () => Promise<void> }> }, KadenaApp: new (t: unknown) => unknown, Buffer: unknown;
-  try {
-    const dyn = (m: string) => import(/* webpackIgnore: true */ m);
-    ({ Buffer } = await dyn('buffer'));
-    (globalThis as unknown as { Buffer?: unknown }).Buffer ??= Buffer;
-    ({ default: TransportWebHID } = await dyn('@ledgerhq/hw-transport-webhid'));
-    ({ KadenaApp } = await dyn('@zondax/ledger-kadena'));
-  } catch {
-    throw new Error('Ledger support is not built into this preview — use the in-browser key or EckoWallet');
-  }
+  // Dynamic imports: Next code-splits these so the Ledger stack loads only
+  // when the user clicks "Ledger". The transport expects the node Buffer
+  // global — shim it first.
+  const { Buffer } = await import('buffer');
+  (globalThis as unknown as { Buffer?: unknown }).Buffer ??= Buffer;
+  const [{ default: TransportWebHID }, { KadenaApp }] = await Promise.all([
+    import('@ledgerhq/hw-transport-webhid'),
+    import('@zondax/ledger-kadena'),
+  ]);
   const transport = await TransportWebHID.create();
   ledgerApp = new KadenaApp(transport) as unknown as typeof ledgerApp;
   const path = "m/44'/626'/0'/0/0";


### PR DESCRIPTION
The Ledger button previously answered "not built into this preview" — the libs were never bundled. This installs the pinned holder-portal dependency set (`@ledgerhq/hw-transport-webhid` ^6.36.0, `@zondax/ledger-kadena` ^0.0.4, `buffer` ^6.0.3) and dynamic-imports them so Next code-splits the Ledger stack behind the button; other pages keep their bundle size. Hash signing (device: Kadena app open, blind/hash signing enabled; browser: Chrome/Edge/Brave for WebHID). Verified: the button now loads the stack and reaches the WebHID device request.