### PR TITLE
lookup: cross-chain totals + per-chain breakdown

### DIFF
--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -6,7 +6,7 @@ import { CFG } from '@/lib/chain';
 import {
   loadOrCreateLocalKey, saveLocalKey, openRounds, alreadyClaimed, poolBalance, masterOpen,
   balance, openProposals, myVote, claim, transfer, transferCrossChain, vote, propose,
-  voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAccount, kdaBalance, importLocalKey,
+  voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance, importLocalKey,
   type Round, type Proposal,
 } from '@/lib/pco';
 import {
@@ -49,7 +49,7 @@ export default function TokenApp() {
   const [rotAccount, setRotAccount] = useState('');
   const [rotKey, setRotKey] = useState('');
   const [lookup, setLookup] = useState('');
-  const [lookupResult, setLookupResult] = useState('');
+  const [lookupResult, setLookupResult] = useState<{ label: string; total?: number; perChain?: { chain: string; balance: number }[] } | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
   const say = (msg: string, kind: Status extends null ? never : 'info' | 'ok' | 'err' = 'info') => setStatus({ msg, kind });
@@ -202,9 +202,16 @@ export default function TokenApp() {
 
   const doLookup = async () => {
     const a = lookup.trim(); if (!a) return;
-    setLookupResult('…');
-    const r = await lookupAccount(a);
-    setLookupResult(r !== null ? `${a.length > 24 ? a.slice(0, 24) + '…' : a} holds ${r.balance.toLocaleString()} PCO` : 'No PCO account found under that name.');
+    setLookupResult({ label: 'Reading all 20 chains…' });
+    const r = await lookupAllChains(a);
+    if (r.perChain.length === 0) {
+      setLookupResult({ label: `${a.length > 24 ? a.slice(0, 24) + '…' : a} holds no PCO on any chain.` });
+    } else {
+      setLookupResult({
+        label: `${a.length > 24 ? a.slice(0, 24) + '…' : a} holds ${r.total.toLocaleString()} PCO across ${r.perChain.length} chain${r.perChain.length > 1 ? 's' : ''}`,
+        total: r.total, perChain: r.perChain,
+      });
+    }
   };
 
   const doPropose = async () => {
@@ -439,7 +446,22 @@ export default function TokenApp() {
           <input placeholder="account (k:… or named)" value={lookup} onChange={(e) => setLookup(e.target.value)} style={{ width: '70%' }} />
           <button className={styles.btn} disabled={busy} onClick={doLookup}>look up</button>
         </p>
-        {lookupResult && <p className={styles.mono}>{lookupResult}</p>}
+        {lookupResult && (
+          <>
+            <p className={styles.mono}>{lookupResult.label}</p>
+            {lookupResult.perChain && (
+              <p className={styles.muted}>
+                Per chain:{' '}
+                <select>
+                  {lookupResult.perChain.map((c) => (
+                    <option key={c.chain} value={c.chain}>chain {c.chain} — {c.balance.toLocaleString()} PCO</option>
+                  ))}
+                </select>
+                {' '}<span>(only chains holding PCO; voting weight counts the hub — chain 0 — balance)</span>
+              </p>
+            )}
+          </>
+        )}
       </section>
 
       {/* ---- Propose ---- */}

--- a/src/lib/chain.ts
+++ b/src/lib/chain.ts
@@ -48,16 +48,20 @@ export const num = (v: unknown): number =>
     ? Number((v as Record<string, unknown>).decimal ?? (v as Record<string, unknown>).int ?? NaN)
     : Number(v);
 
-// Read-only /local call.
-export async function local(code: string): Promise<unknown> {
+// Read-only /local call (hub chain by default; localOn targets any chain).
+export function local(code: string): Promise<unknown> {
+  return localOn(CFG.chain, code);
+}
+export async function localOn(chainId: string, code: string): Promise<unknown> {
   const cmd = JSON.stringify({
     networkId: CFG.networkId,
     payload: { exec: { code, data: {} } },
     signers: [],
-    meta: { chainId: CFG.chain, sender: 'reader', gasLimit: 150000, gasPrice: 1e-8, ttl: 600, creationTime: Math.floor(Date.now() / 1000) - 30 },
+    meta: { chainId, sender: 'reader', gasLimit: 150000, gasPrice: 1e-8, ttl: 600, creationTime: Math.floor(Date.now() / 1000) - 30 },
     nonce: `r:${Date.now()}:${Math.random()}`,
   });
-  const r = await fetch(`${API}/local`, {
+  const api = `${CFG.host}/chainweb/0.0/${CFG.networkId}/chain/${chainId}/pact/api/v1`;
+  const r = await fetch(`${api}/local`, {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ cmd, hash: cmdHash(cmd), sigs: [] }),
   });

--- a/src/lib/pco.ts
+++ b/src/lib/pco.ts
@@ -4,7 +4,7 @@
 //             ONLY sponsored action). Signed by the in-browser throwaway key.
 //   others  — SELF-PAID: transfer / cross-chain / vote / propose. Signed by the
 //             connected wallet, which pays its own coin.GAS.
-import { CFG, T, C, G, local, buildExec, submitAndPoll, cmdHash, signHash } from './chain';
+import { CFG, T, C, G, CHAINS, local, localOn, buildExec, submitAndPoll, cmdHash, signHash } from './chain';
 import { walletSign, type ConnectedWallet, type LocalAccount } from './wallets';
 
 // ---------- reads ----------
@@ -138,6 +138,16 @@ export function rotate(w: ConnectedWallet, account: string, newPubKey: string) {
 export async function lookupAccount(account: string): Promise<{ balance: number } | null> {
   try { return { balance: dec(await local(`(${T}.get-balance "${account}")`)) }; }
   catch { return null; }
+}
+// PCO lives on all 20 chains — read every chain in parallel and keep the
+// nonzero ones (nonexistent accounts on a chain simply read as absent).
+export async function lookupAllChains(account: string): Promise<{ total: number; perChain: { chain: string; balance: number }[] }> {
+  const balances = await Promise.all(CHAINS.map(async (ch) => ({
+    chain: ch,
+    balance: dec(await localOn(ch, `(${T}.get-balance "${account}")`).catch(() => 0)) || 0,
+  })));
+  const perChain = balances.filter((b) => b.balance > 0);
+  return { total: perChain.reduce((s, b) => s + b.balance, 0), perChain };
 }
 export function propose(w: ConnectedWallet, title: string, body: string, days: number) {
   const clean = (s: string) => s.replace(/["\\]/g, '');


### PR DESCRIPTION
Founder feedback: 10 PCO sent to chain 2 didn't show in the lookup (hub-only read). The lookup now queries all 20 chains in parallel and shows the total plus a dropdown of only the chains that hold PCO (0-balance/nonexistent excluded), noting that voting weight counts the hub balance.