### PR TITLE
token: don't offer a transfer we cannot finish, and say what the tally is

### DIFF
--- a/src/app/token/guide/page.tsx
+++ b/src/app/token/guide/page.tsx
@@ -43,7 +43,7 @@ export default function TokenGuide() {
           <li><b>In-browser key</b> — a keypair generated inside your browser (the default). Zero setup, perfect for a first claim. <b>Download the key backup</b> — the key lives only in that browser&apos;s storage; clearing site data deletes it.</li>
           <li><b>EckoWallet</b> — browser extension. Must be on the site&apos;s network (see below).</li>
           <li><b>Zelcore</b> — desktop app. Log in first; the site talks to its local signing API.</li>
-          <li><b>Ledger</b> — hardware, via WebHID (Chrome/Edge/Brave; Kadena app open, hash signing enabled).</li>
+          <li><b>Ledger</b> — hardware, via WebHID (Chrome/Edge/Brave; Kadena app open). The page asks the device to <b>display</b> the transaction so you can check the recipient and amount on the device itself. Leave <b>blind signing off</b>: if the device shows only a hash it cannot tell you what you are approving, and this page will warn you before it continues.</li>
         </ul>
 
         <h2>2 · Claim — free, with any wallet</h2>
@@ -75,21 +75,22 @@ export default function TokenGuide() {
 
         <h2>3 · What is sponsored and what you pay</h2>
         <ul>
-          <li><b>Sponsored (free for you):</b> the claim. Nothing else — this keeps the community gas fund an onboarding fund that cannot be drained by routine activity.</li>
-          <li><b>Self-paid (ordinary gas from your wallet):</b> transfers, cross-chain transfers, voting, proposing, vote-key registration, guard rotation. Fees are tiny fractions of a KDA.</li>
+          <li><b>Sponsored (free for you):</b> the claim — the community gas fund exists to onboard newcomers who hold no KDA. It is capped at a fixed daily budget that refills each day, so it stays an onboarding fund.</li>
+          <li><b>Self-paid (ordinary gas from your wallet):</b> transfers, cross-chain transfers, voting, vote-key registration, guard rotation. Fees are tiny fractions of a KDA. (Questions are authored by the organization, not by holders — see below.)</li>
         </ul>
 
         <h2>4 · Transfers</h2>
         <ul>
           <li><b>Same-chain:</b> enter a <span className={styles.mono}>k:</span> recipient and an amount. Transfers are irreversible — check the recipient twice. A not-yet-existing recipient account is created bound to the key in its name; that is what makes <span className={styles.mono}>k:</span> accounts safe to send to.</li>
-          <li><b>Cross-chain:</b> PCO lives on all 20 Kadena chains; governance lives on chain 0 (the hub). A cross-chain send debits the source chain and, after the SPV proof settles, credits the target chain — the continuation is finished automatically.</li>
+          <li><b>Cross-chain sends are not offered here, on purpose.</b> The token supports them, but a cross-chain move is a two-step transfer: the first step debits the chain you are on, and the credit only lands when someone submits the second step with a proof on the target chain. This page does not do that, so offering it would take your PCO and leave it in a half-finished transfer. Claiming, awards and voting all live on chain 0 in any case, so there is nothing on another chain for PCO to do yet.</li>
         </ul>
 
         <h2 id="voting">5 · Governance — ranked-choice voting on admin-authored questions</h2>
         <ul>
           <li><b>Questions come from the organization; answers come from you.</b> Each on-chain question carries 2–5 named options. The community <b>suggests questions on the public channels</b> (Telegram / X) and the organization puts them on-chain — an accountable public step.</li>
-          <li><b>You vote by ranking the options</b> in order of preference (a partial ranking is fine). Tallies are live <b>Borda scores</b>: with K options, your first choice earns K points per token, the second K−1, and so on. The leading score is the community&apos;s preference; there is no quorum and <b>no vote executes anything on-chain</b>.</li>
-          <li>Voting weight is your <b>current hub-chain balance</b>; re-submitting replaces your ballot, and every balance decrease automatically shrinks your open ballots. Received tokens arrive unvoted.</li>
+          <li><b>You vote by ranking the options</b> in order of preference. A partial ranking is fine and costs you nothing — ranking more options can never hurt your favourite.</li>
+          <li><b>The result is head-to-head.</b> For every pair of options the contract records how much voting weight prefers one to the other, and the winner is the option that beats every other. If none does, that is published as a split rather than broken by an arbitrary rule. A Borda points row is shown too, but only as a completeness diagnostic — points reward ranking fewer options, so they are not the result.</li>
+          <li>Voting weight is your <b>current hub-chain balance</b>, and re-submitting replaces your ballot. If your balance ever falls <b>below</b> the weight recorded on an open ballot, that ballot is automatically trimmed to what you still hold — so you can never keep voting with tokens you no longer have. A decrease that still leaves you above your recorded weight changes nothing. Received tokens arrive unvoted.</li>
           <li>The organization can close a question early only with a <b>public on-chain reason</b>.</li>
         </ul>
         <h2 id="governance-design">Why can&apos;t holders create proposals directly?</h2>

--- a/src/app/token/page.tsx
+++ b/src/app/token/page.tsx
@@ -4,7 +4,7 @@ import TokenPage from '@/components/token/TokenPage';
 export const metadata = {
   title: 'PCO Token',
   description:
-    'The PCO community token: free, deliberately valueless, advisory-only governance — claim, transfer, vote, and propose, all verifiable on-chain.',
+    'The PCO community token: free, deliberately valueless, advisory-only governance — claim, transfer, and vote on organization-authored questions, all verifiable on-chain.',
 };
 
 export default function Token() {

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -5,7 +5,7 @@ import styles from '@/styles/token.module.css';
 import { CFG } from '@/lib/chain';
 import {
   loadOrCreateLocalKey, saveLocalKey, openRounds, alreadyClaimed, poolBalance, masterOpen,
-  balance, openProposals, myBallot, claim, transfer, transferCrossChain, vote,
+  balance, openProposals, myBallot, claim, transfer, vote,
   voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance, importLocalKey,
   type Round, type Proposal,
 } from '@/lib/pco';
@@ -34,7 +34,6 @@ export default function TokenApp() {
   const [rankings, setRankings] = useState<Record<string, number[]>>({});   // in-progress ranking per question
   const [to, setTo] = useState('');
   const [amount, setAmount] = useState('');
-  const [xchain, setXchain] = useState('');
   const [status, setStatus] = useState<Status>(null);
   const [busy, setBusy] = useState(false);
   const [vkActive, setVkActive] = useState(false);
@@ -133,16 +132,14 @@ export default function TokenApp() {
   const AMOUNT_RE = /^\d+(\.\d{1,12})?$/;
   const validTo = /^k:[0-9a-f]{64}$/.test(to);
 
-  const doTransfer = async (direction: 'same' | 'x') => {
+  const doTransfer = async () => {
     if (!wallet) return say('Choose your wallet first (step 1).', 'err');
     if (!validTo) return say('Recipient must be a k: account (k: + 64 hex).', 'err');
     if (!AMOUNT_RE.test(amount) || Number(amount) <= 0) return say('Amount must be a positive number.', 'err');
     const amt = amount.includes('.') ? amount : `${amount}.0`;
-    if (direction === 'x' && (!/^([0-9]|1[0-9])$/.test(xchain) || xchain === CFG.chain)) return say('Cross-chain: pick a chain 0–19 that is not the current chain.', 'err');
     setBusy(true); say(`Sending ${amt} PCO (your wallet pays the gas)…`);
     try {
-      if (direction === 'x') { await transferCrossChain(wallet, to, xchain, amt); say(`Cross-chain send started to chain ${xchain}.`, 'ok'); }
-      else { await transfer(wallet, to, amt); say(`Sent ${amt} PCO.`, 'ok'); }
+      await transfer(wallet, to, amt); say(`Sent ${amt} PCO.`, 'ok');
       setTo(''); setAmount('');
     } catch (e) { say(`Transfer failed: ${(e as Error).message}`, 'err'); }
     setBusy(false); void refresh();
@@ -272,7 +269,7 @@ export default function TokenApp() {
             <p className={styles.mono}>{wallet.account}</p>
             <p>
               Holds: <b>{walletBal.toLocaleString()} PCO</b> · <b>{walletKda.toLocaleString(undefined, { maximumFractionDigits: 4 })} KDA</b>
-              {walletKda < 0.05 && <span className={styles.muted}> — self-paid actions (transfer/vote/propose) need a little KDA; claiming does not</span>}
+              {walletKda < 0.05 && <span className={styles.muted}> — self-paid actions (transfer/vote) need a little KDA; claiming does not</span>}
             </p>
             {wallet.kind === 'localkey' && (
               <>
@@ -369,16 +366,21 @@ export default function TokenApp() {
       {/* ---- Send ---- */}
       <section className={styles.card}>
         <h2>Send PCO</h2>
-        <p className={styles.muted}>Send to a k: account — double-check it, transfers are irreversible. Same-chain or cross-chain.</p>
+        <p className={styles.muted}>Send to a k: account — double-check it, transfers are irreversible.</p>
         <p><input placeholder="k:recipient account" value={to} onChange={(e) => setTo(e.target.value)} style={{ width: '100%' }} /></p>
         <p>
           <input placeholder="amount" value={amount} onChange={(e) => setAmount(e.target.value)} />
-          <button className={styles.btn} disabled={busy || !wallet} onClick={() => doTransfer('same')}>send (this chain)</button>
+          <button className={styles.btn} disabled={busy || !wallet} onClick={() => doTransfer()}>send</button>
         </p>
-        <p>
-          <label className={styles.muted}>cross-chain to chain <input placeholder="0–19" value={xchain} onChange={(e) => setXchain(e.target.value)} style={{ width: '4rem' }} /></label>
-          <button className={styles.btn} disabled={busy || !wallet} onClick={() => doTransfer('x')}>send cross-chain</button>
-        </p>
+        {/* A cross-chain send is DELIBERATELY not offered. It is a two-step
+            defpact: the first step debits the source chain, and the credit only
+            lands when someone submits the continuation with an SPV proof on the
+            target chain. Nothing does that — not this page, and not a relay we
+            control — so offering the button would debit a holder and leave the
+            tokens in a pending pact. Claiming, grants and governance are all
+            hub-only besides, so PCO moved off the hub can do nothing and cannot
+            return by any path this page offers. Do not wire it up again without
+            a continuation that has been proven end to end on a real chain. */}
       </section>
 
       {/* ---- Open questions (ranked-choice) ---- */}
@@ -405,11 +407,47 @@ export default function TokenApp() {
           return (
             <div key={p.pid} className={styles.proposal}>
               <h3>#{p.pid} — {p.title}</h3>
-              <p className={styles.muted}>
-                {p.options.map((o, i) => `${o}: ${p.scores[i]?.toLocaleString() ?? 0} pts`).join(' · ')}
-                {' '}— turnout {p.turnout.toLocaleString()}
-                {mine && <> — your ballot: <b>{mine.ranking.map((i) => p.options[i]).join(' › ')}</b> ({mine.weight})</>}
-              </p>
+              {/* THE RESULT: head-to-head. An option wins a duel when more
+                  voting weight prefers it to the other, and how much of a
+                  ballot a voter filled in cannot change their favourite's
+                  duels — which is why this, and not the points row, is the
+                  published outcome. */}
+              {p.h2h.available ? (
+                <>
+                  <p>
+                    <b>Head-to-head</b>{' '}
+                    {p.h2h.condorcet
+                      ? <>— <b>{p.h2h.condorcet}</b> beats every other option</>
+                      : <>— no option beats every other (the community is split)</>}
+                  </p>
+                  <p className={styles.muted}>
+                    {p.options.map((o, i) => `${o} beats ${p.h2h.wins[i] ?? 0} of ${p.options.length - 1}`).join(' · ')}
+                    {' '}— turnout {p.turnout.toLocaleString()} PCO
+                    {mine && <> — your ballot: <b>{mine.ranking.map((i) => p.options[i]).join(' › ')}</b> ({mine.weight})</>}
+                  </p>
+                  <details>
+                    <summary className={styles.muted}>every pair, and the points row</summary>
+                    <p className={styles.muted}>
+                      {p.options.flatMap((a, i) => p.options.map((b, j) => (i === j ? null :
+                        `${a} ${p.h2h.pairs[i * p.options.length + j] ?? 0} – ${p.h2h.pairs[j * p.options.length + i] ?? 0} ${b}`
+                      ))).filter(Boolean).join(' · ')}
+                    </p>
+                    <p className={styles.muted}>
+                      Borda points (a completeness diagnostic, not the result — ranking fewer
+                      options inflates them):{' '}
+                      {p.options.map((o, i) => `${o}: ${p.scores[i]?.toLocaleString() ?? 0}`).join(' · ')}
+                    </p>
+                  </details>
+                </>
+              ) : (
+                <p className={styles.muted}>
+                  {p.options.map((o, i) => `${o}: ${p.scores[i]?.toLocaleString() ?? 0} pts`).join(' · ')}
+                  {' '}— turnout {p.turnout.toLocaleString()}
+                  {mine && <> — your ballot: <b>{mine.ranking.map((i) => p.options[i]).join(' › ')}</b> ({mine.weight})</>}
+                  <br />This question was opened before head-to-head results existed, so only the
+                  points row is available for it.
+                </p>
+              )}
               <p>
                 {p.options.map((o, i) => (
                   <button key={i} className={styles.btn}

--- a/src/lib/chain.ts
+++ b/src/lib/chain.ts
@@ -37,10 +37,27 @@ export function cmdHash(cmd: string): string {
   return b64url(blake2b(new TextEncoder().encode(cmd), { dkLen: 32 }));
 }
 
-export function signHash(hashB64: string, privHex: string): string {
+const b64urlBytes = (hashB64: string): Uint8Array => {
   const pad = hashB64.replace(/-/g, '+').replace(/_/g, '/');
-  const bytes = Uint8Array.from(atob(pad), (c) => c.charCodeAt(0));
-  return bytesToHex(ed25519.sign(bytes, hexToBytes(privHex)));
+  return Uint8Array.from(atob(pad), (c) => c.charCodeAt(0));
+};
+
+export function signHash(hashB64: string, privHex: string): string {
+  return bytesToHex(ed25519.sign(b64urlBytes(hashB64), hexToBytes(privHex)));
+}
+
+// Verify that a signature returned by a wallet really covers OUR command hash under
+// the public key of the account we believe is connected. Without this the page will
+// happily POST any 128-hex string a wallet hands back and let the node reject it —
+// which turns "the wallet signed something else" into an opaque server error instead
+// of a precise local one.
+export function verifyHashSig(hashB64: string, sigHex: string, pubHex: string): boolean {
+  try {
+    if (!/^[0-9a-f]{128}$/i.test(sigHex) || !/^[0-9a-f]{64}$/i.test(pubHex)) return false;
+    return ed25519.verify(hexToBytes(sigHex), b64urlBytes(hashB64), hexToBytes(pubHex));
+  } catch {
+    return false;
+  }
 }
 
 export const num = (v: unknown): number =>
@@ -103,7 +120,16 @@ export async function submitAndPoll(signed: { cmd: string; hash: string; sigs: {
   });
   if (!send.ok) throw new Error(`send: ${send.status} ${await send.text()}`);
   const { requestKeys } = await send.json();
-  const rk = requestKeys[0];
+  const rk = requestKeys?.[0];
+  // The request key IS the command hash. A node that returns anything else is either
+  // broken or lying, and polling its key would report the outcome of a DIFFERENT
+  // transaction back to the user as if it were theirs.
+  if (rk !== signed.hash) {
+    throw new Error(
+      `node returned request key ${String(rk).slice(0, 16)}… for a transaction whose hash is ` +
+      `${signed.hash.slice(0, 16)}… — refusing to report its result. Do not trust this endpoint.`,
+    );
+  }
   for (let i = 0; i < 60; i++) {
     await new Promise((res) => setTimeout(res, 3000));
     const r = await fetch(`${API}/poll`, {

--- a/src/lib/pco.ts
+++ b/src/lib/pco.ts
@@ -2,8 +2,10 @@
 //
 //   claim   — GASLESS: the on-chain gas station pays (station-sponsored, the
 //             ONLY sponsored action). Signed by the in-browser throwaway key.
-//   others  — SELF-PAID: transfer / cross-chain / vote / propose. Signed by the
-//             connected wallet, which pays its own coin.GAS.
+//   others  — SELF-PAID: transfer / cross-chain / vote / vote-key / rotate. Signed
+//             by the connected wallet, which pays its own coin.GAS. (Proposals are
+//             ADMIN-AUTHORED — PROPOSAL-OPS gates create/cancel to the gov or ops
+//             keyset — so this library deliberately exposes no propose path.)
 import { CFG, T, C, G, CHAINS, local, localOn, buildExec, submitAndPoll, cmdHash, signHash } from './chain';
 import { walletSign, type ConnectedWallet, type LocalAccount } from './wallets';
 
@@ -43,17 +45,29 @@ export async function alreadyClaimed(roundId: string, account: string): Promise<
 }
 // Ranked-choice questions: options + live Borda scores (a ballot ranking
 // option i at position p contributes weight*(K-p) points).
-export type Proposal = { pid: string; title: string; options: string[]; scores: number[]; turnout: number };
+// The AUTHORITATIVE result is the head-to-head record; the Borda `scores` are
+// kept only as a truncation diagnostic (ranking fewer options inflates them).
+export type Proposal = {
+  pid: string; title: string; options: string[]; scores: number[]; turnout: number;
+  h2h: { available: boolean; pairs: number[]; wins: number[]; condorcet: string };
+};
 export async function openProposals(): Promise<Proposal[]> {
   const ids = (await local(`(${T}.open-ids)`)) as string[];
   const out: Proposal[] = [];
   for (const pid of ids) {
     const r = (await local(`(${T}.get-results "${pid}")`)) as Record<string, unknown>;
+    const h = (await local(`(${T}.get-head-to-head "${pid}")`).catch(() => null)) as Record<string, unknown> | null;
     out.push({
       pid, title: String(r.title ?? ''),
       options: (r.options as string[]) ?? [],
       scores: ((r.scores as unknown[]) ?? []).map(dec),
       turnout: dec(r.turnout),
+      h2h: {
+        available: Boolean(h?.available),
+        pairs: ((h?.pairs as unknown[]) ?? []).map(dec),
+        wins: ((h?.wins as unknown[]) ?? []).map(dec),
+        condorcet: String(h?.condorcet ?? ''),
+      },
     });
   }
   return out;
@@ -104,6 +118,18 @@ export function transfer(w: ConnectedWallet, to: string, amount: string) {
     [{ name: `${T}.TRANSFER`, args: [w.account, to, { decimal: amount }] }],
     { rg: { keys: [to.slice(2)], pred: 'keys-all' } });
 }
+// DELIBERATELY NOT WIRED INTO THE UI. This submits step 0 of a two-step defpact:
+// it debits the source chain, and the credit only lands when someone submits the
+// continuation with an SPV proof on the TARGET chain. Nothing does that — not this
+// page, and not a relay we operate — so exposing it debits a holder and leaves the
+// tokens in a pending pact. The guide used to promise the continuation "is finished
+// automatically", which was false.
+// Kept here, unexposed, because the call itself is correct and a real relay is a
+// reasonable future feature: fetch the proof from the source chain's /spv endpoint
+// and submit the continuation on the target chain with the public
+// `kadena-xchain-gas` station as the gas payer (the holder will not have KDA
+// there). Do not re-export this to the UI until that path is proven end to end on
+// a real chain — a half-built relay strands funds more quietly than no relay.
 export function transferCrossChain(w: ConnectedWallet, to: string, targetChain: string, amount: string) {
   return selfPaid(w,
     `(${T}.transfer-crosschain "${w.account}" "${to}" (read-keyset 'rg) "${targetChain}" ${amount})`,
@@ -123,12 +149,14 @@ export function voteAs(w: ConnectedWallet, coldAccount: string, pid: string, ran
 // to VOTE-KEY-ADMIN). The hot key can then ONLY vote — nothing else.
 export function setVoteKey(w: ConnectedWallet, hotPubKey: string) {
   return selfPaid(w, `(${T}.set-vote-key "${w.account}" (read-keyset 'vk))`,
-    [{ name: `${T}.VOTE-KEY-ADMIN`, args: [w.account] }],
+    // the registered key's principal is IN the capability, so a substituted
+    // key changes what the wallet displays (audit F-12)
+    [{ name: `${T}.VOTE-KEY-ADMIN`, args: [w.account, `k:${hotPubKey}`] }],
     { vk: { keys: [hotPubKey], pred: 'keys-all' } });
 }
 export function clearVoteKey(w: ConnectedWallet) {
   return selfPaid(w, `(${T}.clear-vote-key "${w.account}")`,
-    [{ name: `${T}.VOTE-KEY-ADMIN`, args: [w.account] }]);
+    [{ name: `${T}.VOTE-KEY-ADMIN`, args: [w.account, ''] }]);
 }
 export async function voteKeyActive(account: string): Promise<boolean> {
   return Boolean(await local(`(at 'active (${T}.get-vote-key "${account}"))`).catch(() => false));
@@ -139,7 +167,10 @@ export async function voteKeyActive(account: string): Promise<boolean> {
 // the UI enforces this before building the transaction.
 export function rotate(w: ConnectedWallet, account: string, newPubKey: string) {
   return selfPaid(w, `(${T}.rotate "${account}" (read-keyset 'ng))`,
-    [{ name: `${T}.ROTATE`, args: [account] }],
+    // the DESTINATION guard's principal is IN the capability, so a hostile
+    // page cannot swap the data block and install another key under a
+    // signature the user verified (audit F-12)
+    [{ name: `${T}.ROTATE`, args: [account, `k:${newPubKey}`] }],
     { ng: { keys: [newPubKey], pred: 'keys-all' } });
 }
 // Read-only lookups — no wallet, no signature.

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -10,7 +10,7 @@
 // buildExec); wallets only contribute signatures over OUR hash. DEVNET PREVIEW:
 // wallets must be pointed at the devnet network — adapters surface honest
 // errors when they are not.
-import { CFG, cmdHash, signHash, bytesToHex, type Cap } from './chain';
+import { CFG, cmdHash, signHash, verifyHashSig, bytesToHex, type Cap } from './chain';
 import { blake2b } from '@noble/hashes/blake2b';
 
 const NETWORK_ID = CFG.networkId;
@@ -159,7 +159,14 @@ export async function connectZelcore(): Promise<ConnectedWallet> {
 }
 
 // ---------------- Ledger (WebHID, loaded on demand) ----------------
-let ledgerApp: { transport?: { close?: () => Promise<void> }; getAddressAndPubKey: (p: string) => Promise<{ pubkey?: Uint8Array; publicKey?: Uint8Array }>; signHash: (p: string, h: string) => Promise<{ signature?: Uint8Array }> } | null = null;
+let ledgerApp: {
+  transport?: { close?: () => Promise<void> };
+  getAddressAndPubKey: (p: string) => Promise<{ pubkey?: Uint8Array; publicKey?: Uint8Array }>;
+  // clear-sign: the device parses and DISPLAYS the command blob
+  sign: (p: string, blob: Uint8Array) => Promise<{ signature?: Uint8Array }>;
+  // blind-sign fallback: the device shows only a digest
+  signHash: (p: string, h: string) => Promise<{ signature?: Uint8Array }>;
+} | null = null;
 export async function connectLedger(): Promise<ConnectedWallet> {
   if (!('hid' in navigator)) throw new Error('This browser has no WebHID (use Chrome/Edge/Brave) — Ledger unavailable');
   // Dynamic imports: Next code-splits these so the Ledger stack loads only
@@ -198,14 +205,58 @@ export async function connectLedger(): Promise<ConnectedWallet> {
   if (!pub || pub.length !== 64) throw new Error('Ledger returned no public key — open the Kadena app on the device');
   return {
     kind: 'ledger', label: 'Ledger', account: `k:${pub}`, publicKey: pub,
+    // CLEAR-SIGN FIRST. `sign(path, blob)` hands the device the FULL command so it
+    // can parse and render recipient / amount / chain / capabilities on its screen.
+    // `signHash` shows a bare 32-byte digest, which means the device cannot protect
+    // the user from a compromised page at all (the Bybit/Safe failure mode) — so it
+    // is a fallback only, and only behind an explicit acknowledgement.
     async sign(cmd) {
-      const r = await ledgerApp!.signHash(path, bytesToHex(hashBytes(cmd)));
-      const sig = r?.signature ? bytesToHex(new Uint8Array(r.signature)) : null;
-      if (!sig) throw new Error('Ledger did not sign (rejected on device, or blind signing disabled)');
-      return sig;
+      try {
+        const { Buffer } = await import('buffer');
+        const r = await ledgerApp!.sign(path, Buffer.from(cmd, 'utf8'));
+        const sig = r?.signature ? bytesToHex(new Uint8Array(r.signature)) : null;
+        if (sig) return sig;
+        throw new Error('device returned no signature');
+      } catch (e) {
+        const m = e instanceof Error ? e.message : String(e);
+        // A user rejection must NOT silently escalate to blind signing.
+        if (/reject|denied|cancel|0x6985|conditions of use/i.test(m)) {
+          throw new Error('Signing rejected on the Ledger.');
+        }
+        if (!(await confirmBlindSign())) {
+          throw new Error(
+            'Ledger could not display this transaction, and blind signing was declined. ' +
+            'Nothing was signed.',
+          );
+        }
+        const r = await ledgerApp!.signHash(path, bytesToHex(hashBytes(cmd)));
+        const sig = r?.signature ? bytesToHex(new Uint8Array(r.signature)) : null;
+        if (!sig) throw new Error('Ledger did not sign (rejected on device, or blind signing disabled)');
+        return sig;
+      }
     },
     disconnect() { ledgerApp?.transport?.close?.().catch(() => {}); ledgerApp = null; },
   };
+}
+
+// Blind-signing acknowledgement. The page MUST NOT fall back to hash-signing without
+// the user understanding that the device is showing them nothing. Replaceable by the
+// UI (setBlindSignConfirm) with a proper modal; the default refuses in a non-browser
+// context rather than signing blind.
+let blindSignConfirm: (() => Promise<boolean>) | null = null;
+export function setBlindSignConfirm(fn: (() => Promise<boolean>) | null) {
+  blindSignConfirm = fn;
+}
+async function confirmBlindSign(): Promise<boolean> {
+  if (blindSignConfirm) return blindSignConfirm();
+  if (typeof window === 'undefined') return false;
+  return window.confirm(
+    'BLIND SIGNING\n\n' +
+    'Your Ledger could not display this transaction, so it will show only a hash — ' +
+    'the device cannot show you what you are approving, and cannot protect you if this ' +
+    'page has been tampered with.\n\n' +
+    'Only continue if you trust this page right now. Continue?',
+  );
 }
 
 // ---------------- In-browser test key (the gasless-claim key) ----------------
@@ -217,9 +268,23 @@ export function connectLocalKey(acct: LocalAccount): ConnectedWallet {
   };
 }
 
-// Sign our unsigned command with the connected wallet; verify it covers OUR hash.
+// Sign our unsigned command with the connected wallet, then CRYPTOGRAPHICALLY VERIFY
+// that what came back really is a signature over OUR command hash by the account we
+// display as connected.
+//
+// (The previous version compared cmdHash(unsigned.cmd) against unsigned.hash — two
+// values produced from the same literal in buildExec, so the check could never fire,
+// and it ran after signing anyway. Audit finding: the comment claimed a control that
+// did not exist.)
 export async function walletSign(w: ConnectedWallet, unsigned: { cmd: string; hash: string }, capsHint: Cap[]): Promise<{ cmd: string; hash: string; sigs: { sig: string }[] }> {
+  if (cmdHash(unsigned.cmd) !== unsigned.hash) throw new Error('internal: command hash does not match its command');
   const sig = await w.sign(unsigned.cmd, unsigned.hash, capsHint);
-  if (cmdHash(unsigned.cmd) !== unsigned.hash) throw new Error('internal: command changed after hashing');
+  if (!verifyHashSig(unsigned.hash, sig, w.publicKey)) {
+    throw new Error(
+      `${w.label} returned a signature that does not cover this transaction under ` +
+      `${w.account.slice(0, 14)}… — nothing was submitted. Reconnect and try again; if it ` +
+      `repeats, do not retry on this page.`,
+    );
+  }
   return { cmd: unsigned.cmd, hash: unsigned.hash, sigs: [{ sig }] };
 }


### PR DESCRIPTION
Closes **LAUNCH-BLOCKERS B2** and corrects three claims the page made that the contract does not keep. The rule they share: a page that debits a holder is a promise, and it has to be one we can honour.

## Cross-chain sends removed

The page offered a "cross-chain to chain 0–19" input and the guide said *"the continuation is finished automatically."* Neither was true.

A cross-chain move is a two-step defpact: step 0 debits the chain you are on, and the credit lands only when someone submits the continuation with an SPV proof on the **target** chain. Nothing did that — not the page, not a relay we operate. So the button took a holder's PCO and left it in a pending pact. Claiming, awards and voting are hub-only besides, so PCO moved off chain 0 could do nothing and had no way back.

`transferCrossChain` stays in the lib, unexposed, with the real implementation path written down (proof from the source chain's `/spv`, continuation on the target chain paid by the public `kadena-xchain-gas` station, since the holder will have no KDA there) so a future relay starts from the right place instead of someone re-wiring the button.

## The tally is head-to-head

The guide presented Borda points as the result. The contract's authoritative record is the pairwise margin matrix; Borda is a truncation diagnostic, and points reward ranking *more* options, so they are not the verdict. The page now reads `get-head-to-head` and reports a Condorcet winner or an honest split.

## Ballot trimming, stated as it works

*"Every balance decrease automatically shrinks your open ballots"* was false. `release-votes` trims only when recorded weight **exceeds** balance — a holder with 200 who votes 100 and sends 60 keeps a 100-weight ballot. The safety property is real (you can never vote tokens you no longer hold) but it is a **cap, not a subtraction**, and the sentence claimed the stronger thing.

## Also

- Proposing removed from the self-paid list — questions are admin-authored, `PROPOSAL-OPS` gates create and cancel.
- The sponsorship line no longer says "Nothing else" without saying what actually bounds the fund.
- Ledger asks the device to **display** the transaction instead of blind-signing a hash, and warns first if only a hash can be shown.
- Two fail-closed client checks matching the ceremony tooling's discipline: verify locally that a wallet signature covers *our* command hash under the connected key, and refuse to poll a request key that is not the command hash — otherwise a node returning a different key reports a stranger's transaction as the user's own.

## Verification

- `npm run lint` clean · `npm run build` clean (16 pages)
- **Every contract call the site makes resolves to a real `defun`/`defcap`** in the shipped contracts, checked with `pco-token`'s `ui-contract-check.py` against `contracts/`. That scanner needed a fix to see this repo at all — it globbed `.js`/`.ts` only, so a Next.js app's `.tsx` was invisible to it (PR in `pco-token-ops`).
- Config unchanged: still devnet-pointed with the mainnet block staged and commented.