### PR TITLE
token: tell people their answer matches before they click

### DIFF
--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -352,13 +352,24 @@ export default function TokenApp() {
           </select>
         </p>
         <p>
-          <input placeholder="engagement code" value={code} onChange={(e) => setCode(e.target.value)} />
+          <input placeholder="answer" value={code} onChange={(e) => setCode(e.target.value)} />
           <button className={styles.btn}
             disabled={busy || !open || !round || claimed || (destEdited && !/^k:[0-9a-f]{64}$/.test(destAddr.trim()))}
             onClick={doClaim}>
             {round ? `claim ${round.amount} PCO` : 'claim'}
           </button>
         </p>
+        {/* Live feedback. The round's code hash is public chain data and the check
+            is local, so we can tell the user their answer is right BEFORE they
+            click — and a wrong one never becomes a transaction, so trying again
+            costs nothing and takes nothing from the sponsorship budget. */}
+        {round && code.trim() !== '' && (
+          <p className={styles.muted}>
+            {checkCode(round, code)
+              ? '✓ that matches — click claim'
+              : 'not a match yet. Answers are lowercase and trimmed for you; nothing is submitted until it matches, so guessing is free.'}
+          </p>
+        )}
         {claimed && (
           <p className={styles.muted}>
             {destEdited && destAddr.trim() !== wallet?.account ? `That address (${destAddr.trim().slice(0, 14)}…)` : `Your active wallet (${wallet?.account.slice(0, 14)}…)`} already


### PR DESCRIPTION
Small follow-up to #119.

The round's `code-hash` is public chain data and the check is local, so the page can confirm a correct answer **the moment it is typed** rather than after a round-trip. A wrong one still never becomes a transaction, so the hint says plainly that guessing is free — worth stating, because the opposite used to be true and it cost the gas station.

Placeholder is now `answer` rather than `engagement code`: the announcement asks a question, so that's the word people arrive with.

**No answer and no hash are in this source, and none should be added.** The hash is read per round from `get-round`; hardcoding it would duplicate chain state, drift the moment a round changes, and force a redeploy for every new round.