### PR TITLE
remove the "paste a secret key" field; say which chain a balance is on

### DIFF
--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -6,7 +6,7 @@ import { CFG } from '@/lib/chain';
 import {
   loadOrCreateLocalKey, saveLocalKey, openRounds, alreadyClaimed, poolBalance, masterOpen,
   balance, openProposals, myBallot, claim, transfer, vote,
-  voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance, importLocalKey,
+  voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance,
   type Round, type Proposal, checkCode } from '@/lib/pco';
 import {
   connectEcko, connectZelcore, connectLedger, connectLocalKey, eckoAvailable,
@@ -41,7 +41,6 @@ export default function TokenApp() {
   const [walletKda, setWalletKda] = useState(0);
   const [destAddr, setDestAddr] = useState('');
   const [destEdited, setDestEdited] = useState(false);   // user typed their own receiving address
-  const [secretIn, setSecretIn] = useState('');
   const [rotAccount, setRotAccount] = useState('');
   const [rotKey, setRotKey] = useState('');
   const [lookup, setLookup] = useState('');
@@ -274,8 +273,11 @@ export default function TokenApp() {
             </p>
             <p className={styles.mono}>{wallet.account}</p>
             <p>
-              Holds: <b>{walletBal.toLocaleString()} PCO</b> · <b>{walletKda.toLocaleString(undefined, { maximumFractionDigits: 4 })} KDA</b>
-              {walletKda < 0.05 && <span className={styles.muted}> — self-paid actions (transfer/vote) need a little KDA; claiming does not</span>}
+              {/* Kadena balances are PER CHAIN. An unqualified "Holds: 0 KDA" reads as
+                  "you have no KDA", when the user may hold plenty on another chain — and
+                  then the advice to fund it is wrong. Name the chain. */}
+              Holds on <b>chain {CFG.chain}</b>: <b>{walletBal.toLocaleString()} PCO</b> · <b>{walletKda.toLocaleString(undefined, { maximumFractionDigits: 4 })} KDA</b>
+              {walletKda < 0.05 && <span className={styles.muted}> — self-paid actions (transfer/vote) need a little KDA <i>on this chain</i>; claiming does not. KDA held on another Kadena chain has to be moved here first.</span>}
             </p>
             {wallet.kind === 'localkey' && (
               <>
@@ -285,16 +287,17 @@ export default function TokenApp() {
                   <button className={styles.btn} onClick={restore}>restore from backup</button>
                   <input ref={fileRef} type="file" accept="application/json" hidden onChange={onRestore} />
                 </p>
-                <p>
-                  <input placeholder="import a secret key (64 hex) to sign with it" value={secretIn} onChange={(e) => setSecretIn(e.target.value)} style={{ width: '70%' }} />
-                  <button className={styles.btn} disabled={busy || !secretIn.trim()} onClick={() => {
-                    try {
-                      const a = importLocalKey(secretIn);
-                      setKey(a); setWallet(connectLocalKey(a)); setSecretIn('');
-                      say('Secret key imported — it is now the active in-browser wallet. (It replaced the previous browser key; a downloaded backup still restores that one.)', 'ok');
-                    } catch (e) { say(`Import failed: ${(e as Error).message}`, 'err'); }
-                  }}>import</button>
-                </p>
+                  {/* There was a "paste a secret key here" field. It is gone, and
+                      nothing like it should return. A text box asking for private key
+                      material is the exact shape of every wallet-drainer phishing page,
+                      and putting one on an official site teaches the habit that gets
+                      people robbed on a fake one. Restoring from a backup file this
+                      page itself produced is a different act and stays. */}
+                  <p className={styles.muted}>
+                    <b>PCO will never ask for your seed phrase or a private key.</b> Not here,
+                    not by message, not ever. Anyone asking for one is not us — including a
+                    page that looks exactly like this one.
+                  </p>
               </>
             )}
             {wallet.kind !== 'localkey' && (

--- a/src/lib/pco.ts
+++ b/src/lib/pco.ts
@@ -259,14 +259,12 @@ export function saveLocalKey(acct: LocalAccount) {
 // Import a raw ed25519 secret key as the in-browser wallet (REPLACES the
 // stored key — the caller must warn the user). Hex case is normalized; the
 // derived public key determines the k: account.
-export function importLocalKey(secretHex: string): LocalAccount {
-  const sk = secretHex.trim().toLowerCase();
-  if (!/^[0-9a-f]{64}$/.test(sk)) throw new Error('a secret key is 64 hex characters');
-  const pub = pubFromPriv(sk);
-  const acct: LocalAccount = { account: `k:${pub}`, publicKey: pub, secretKey: sk };
-  saveLocalKey(acct);
-  return acct;
-}
+// importLocalKey was REMOVED (2026-08-01). It backed a "paste a secret key here"
+// field on the token page — the exact shape of a wallet-drainer phishing form.
+// Shipping one on an official site teaches the habit that gets people robbed on
+// a fake one. The browser key is generated here and backed up to a file this
+// page produces; there is no legitimate reason to accept pasted key material.
+// Do not reintroduce it.
 // small helper so pco.ts stays self-contained
 import { ed25519 } from '@noble/curves/ed25519';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';


### PR DESCRIPTION
Two catches from the founder, both about the page contradicting itself.

## The secret-key import field

The token page had a text input reading **"import a secret key (64 hex) to sign with it"** — a few lines under our own safety messaging.

That is the exact shape of every wallet-drainer phishing page. Putting one on the official site teaches the habit that gets people robbed on a fake one, and it makes *"we will never ask for your seed"* ring hollow while we have a box asking for key material.

Removed from the UI **and** the library, with the reason recorded in both so nobody adds it back as a convenience.

**Restoring from a backup file this page produced stays** — that exists so a cleared browser doesn't cost someone their claim, and accepting a file we generated is a different act from accepting pasted key material.

In its place, the statement that field should always have been:

> **PCO will never ask for your seed phrase or a private key.** Not here, not by message, not ever. Anyone asking for one is not us — including a page that looks exactly like this one.

## The balance line

It read `Holds: 0 PCO · 0 KDA`.

**Kadena balances are per chain.** An unqualified zero reads as "you have no KDA" to someone holding plenty on another chain — and the hint that follows (*"self-paid actions need a little KDA"*) is then simply wrong for them.

Now: `Holds on chain 0: …`, and the low-balance hint says the KDA must be **on this chain**, and that funds held elsewhere have to be moved here first.

## Why these mattered

Neither is a security hole. Both are the page telling a user something untrue about their own situation — which is how someone ends up funding an account they didn't need to fund, or pasting a key they should never paste.