### PR TITLE
token: claiming asks the user for nothing — ephemeral gas signer, no browser keys, hydration fix

### DIFF
--- a/src/app/token/guide/page.tsx
+++ b/src/app/token/guide/page.tsx
@@ -37,21 +37,20 @@ export default function TokenGuide() {
         <p>
           The <Link href="/token">token page</Link> uses <b>one active wallet at a time</b>: claims
           land there, balances show for it, votes and transfers come from it. Never two identities
-          at once — switching wallets switches everything. Four options:
+          at once — switching wallets switches everything. Three options:
         </p>
         <ul>
-          <li><b>In-browser key</b> — a keypair generated inside your browser (the default). Zero setup, perfect for a first claim. <b>Download the key backup</b> — the key lives only in that browser&apos;s storage; clearing site data deletes it.</li>
-          <li><b>EckoWallet</b> — browser extension. Must be on the site&apos;s network (see below).</li>
+                    <li><b>EckoWallet</b> — browser extension. Must be on the site&apos;s network (see below).</li>
           <li><b>Zelcore</b> — desktop app. Log in first; the site talks to its local signing API.</li>
           <li><b>Ledger</b> — hardware, via WebHID (Chrome/Edge/Brave; Kadena app open). The page asks the device to <b>display</b> the transaction so you can check the recipient and amount on the device itself. Leave <b>blind signing off</b>: if the device shows only a hash it cannot tell you what you are approving, and this page will warn you before it continues.</li>
         </ul>
 
         <h2>2 · Claim — free, with any wallet</h2>
         <p>
-          Claiming is the one action whose gas is <b>sponsored</b> by the on-chain gas station — and
-          your wallet never signs for it (claims need no signature from the claimer; tokens can only
-          land in the account bound to the supplied guard). Even a Ledger claim needs no device
-          interaction.
+          Claiming is the one action whose gas is <b>sponsored</b> by the on-chain gas station, so
+          <b>you need no KDA to claim</b>. Your wallet signs one thing: permission for the station to
+          pay the fee. It never authorises a transfer of your funds, and the tokens can only land in
+          the account bound to the guard supplied with the claim.
         </p>
         <ul>
           <li>Pick the open claim round and answer its quest. Quests are published on the PCO channels together with the round id; the answer, normalized to lowercase, is the claim code.</li>
@@ -133,7 +132,7 @@ export default function TokenGuide() {
         <h2>9 · Fair play and safety</h2>
         <ul>
           <li>Official rounds exist on-chain before they are announced anywhere. We never direct-message claim links, and there is nothing to buy — ever.</li>
-          <li>The claim page never asks for a seed phrase. The in-browser key is generated locally; back it up and treat the backup like a password.</li>
+          <li>The claim page never asks for a seed phrase or a private key, and never generates one for you. Every signature comes from a wallet you already control. Any page asking you to paste key material is not ours — including one that looks exactly like this.</li>
           <li>Round budgets bound worst-case abuse; one-claim-per-account-per-round is the on-chain rule.</li>
         </ul>
 

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from '@/styles/token.module.css';
 import { CFG } from '@/lib/chain';
 import {
-  openRounds, alreadyClaimed, poolBalance, masterOpen,
+  dryRunClaimSignature, openRounds, alreadyClaimed, poolBalance, masterOpen,
   balance, openProposals, myBallot, claim, transfer, vote,
   voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance,
   type Round, type Proposal, checkCode } from '@/lib/pco';
@@ -47,6 +47,27 @@ export default function TokenApp() {
   const [lookupResult, setLookupResult] = useState<{ label: string; total?: number; perChain?: { chain: string; balance: number }[] } | null>(null);
 
   const say = (msg: string, kind: Status extends null ? never : 'info' | 'ok' | 'err' = 'info') => setStatus({ msg, kind });
+
+  // DEV-ONLY signing probe. Lets a real wallet sign the real claim transaction
+  // and verify the signature, without submitting — the one risk that typecheck
+  // and build cannot cover. Stripped from any production build by the guard.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') return;
+    (window as unknown as Record<string, unknown>).__pcoSignTest = async (destAcct?: string) => {
+      const r = selectedRound();
+      if (!r) throw new Error('no open round');
+      if (!wallet) throw new Error('connect a wallet first');
+      const a = (destAcct ?? wallet.account).trim();
+      if (!/^k:[0-9a-f]{64}$/.test(a)) throw new Error('destination must be a k: account');
+      const out = await dryRunClaimSignature(r, { account: a, publicKey: a.slice(2) }, wallet, code);
+      console.log('%c✓ wallet signed the sponsored claim shape — NOTHING was submitted', 'color:green;font-weight:bold');
+      console.log('  wallet   ', wallet.label, wallet.account);
+      console.log('  sender   ', out.station, '(the gas station, not the wallet)');
+      console.log('  hash     ', out.hash);
+      console.log('  signature', out.sig.slice(0, 32) + '…');
+      return out;
+    };
+  }, [wallet, code, rounds, roundId]);
 
   const refresh = useCallback(async () => {
     try {

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from '@/styles/token.module.css';
 import { CFG } from '@/lib/chain';
 import {
-  dryRunClaimSignature, openRounds, alreadyClaimed, poolBalance, masterOpen,
+  openRounds, alreadyClaimed, poolBalance, masterOpen,
   balance, openProposals, myBallot, claim, transfer, vote,
   voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance,
   type Round, type Proposal, checkCode } from '@/lib/pco';
@@ -69,27 +69,6 @@ export default function TokenApp() {
     return () => { done = true; timers.forEach(clearTimeout); clearTimeout(settle); };
   }, []);
 
-  // DEV-ONLY signing probe. Lets a real wallet sign the real claim transaction
-  // and verify the signature, without submitting — the one risk that typecheck
-  // and build cannot cover. Stripped from any production build by the guard.
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') return;
-    (window as unknown as Record<string, unknown>).__pcoSignTest = async (destAcct?: string) => {
-      const r = selectedRound();
-      if (!r) throw new Error('no open round');
-      if (!wallet) throw new Error('connect a wallet first');
-      const a = (destAcct ?? wallet.account).trim();
-      if (!/^k:[0-9a-f]{64}$/.test(a)) throw new Error('destination must be a k: account');
-      const out = await dryRunClaimSignature(r, { account: a, publicKey: a.slice(2) }, wallet, code);
-      console.log('%c✓ wallet signed the sponsored claim shape — NOTHING was submitted', 'color:green;font-weight:bold');
-      console.log('  wallet   ', wallet.label, wallet.account);
-      console.log('  sender   ', out.station, '(the gas station, not the wallet)');
-      console.log('  hash     ', out.hash);
-      console.log('  signature', out.sig.slice(0, 32) + '…');
-      return out;
-    };
-  }, [wallet, code, rounds, roundId]);
-
   const refresh = useCallback(async () => {
     try {
       // There is no default wallet any more: the page generates no keys, so
@@ -137,16 +116,22 @@ export default function TokenApp() {
 
   const doClaim = async () => {
     const round = selectedRound();
-    if (!wallet) return say('Choose your wallet first (step 1).', 'err');
     if (!round) return say('No open round right now.', 'err');
-    if (!code.trim()) return say('Enter the engagement code first.', 'err');
-    // destination = the active wallet, OR a pasted k: address. No destination
-    // signature is needed — claims have no claimer signature by design; the
-    // the wallet only signs the station's GAS_PAYER capability.
-    const a = (destEdited ? destAddr.trim() : wallet.account);
-    if (!/^k:[0-9a-f]{64}$/.test(a)) return say('That is not a valid k: account — expected "k:" + 64 lowercase hex characters. Check for typos before claiming.', 'err');
+    if (!code.trim()) return say('Enter the answer first.', 'err');
+    // NO WALLET IS REQUIRED TO CLAIM. Claims carry no claimer signature — tokens
+    // can only land in the account bound to the guard supplied with the claim —
+    // and the station's fee is authorised by an ephemeral in-memory key. All the
+    // page needs is a destination: the connected wallet if there is one, or an
+    // address typed in by someone who has no wallet connected at all (a hardware
+    // wallet in a safe, a friend's account, a fresh address).
+    const a = (destEdited || !wallet) ? destAddr.trim() : wallet.account;
+    if (!/^k:[0-9a-f]{64}$/.test(a)) {
+      return say(wallet
+        ? 'That is not a valid k: account — expected "k:" + 64 lowercase hex characters. Check for typos before claiming.'
+        : 'Paste the k: address the tokens should go to — "k:" + 64 lowercase hex characters. No wallet needed to claim.', 'err');
+    }
     const dest = { account: a, publicKey: a.slice(2) };
-    const destLabel = destEdited && a !== wallet.account ? `${a.slice(0, 14)}…` : `your ${wallet.label} account`;
+    const destLabel = wallet && !destEdited ? `your ${wallet.label} account` : `${a.slice(0, 14)}…`;
     // Check the answer BEFORE any spinner or network work. A wrong answer is
     // caught here for free; submitting it would spend the gas station's float on
     // a transaction that cannot succeed, and enough of those exhaust the daily
@@ -154,8 +139,8 @@ export default function TokenApp() {
     if (!checkCode(round, code)) {
       return say("That answer doesn't match this round — nothing was submitted, so try again freely.", 'err');
     }
-    setBusy(true); say(`Claiming "${round.id}" to ${destLabel} (the gas station pays the fee)…`);
-    try { await claim(round, dest, wallet, code.trim().toLowerCase()); say(`Claimed ${round.amount} PCO to ${dest.account.slice(0, 14)}…!`, 'ok'); setCode(''); }
+    setBusy(true); say(`Claiming "${round.id}" to ${destLabel} (the gas station pays the fee — nothing to sign)…`);
+    try { await claim(round, dest, code.trim().toLowerCase()); say(`Claimed ${round.amount} PCO to ${dest.account.slice(0, 14)}…!`, 'ok'); setCode(''); }
     catch (e) { say(`Claim failed: ${(e as Error).message}`, 'err'); }
     setBusy(false); void refresh();
   };
@@ -371,7 +356,7 @@ export default function TokenApp() {
         <p>
           <input placeholder="answer" value={code} onChange={(e) => setCode(e.target.value)} />
           <button className={styles.btn}
-            disabled={busy || !open || !round || claimed || (destEdited && !/^k:[0-9a-f]{64}$/.test(destAddr.trim()))}
+            disabled={busy || !open || !round || claimed || ((destEdited || !wallet) && !/^k:[0-9a-f]{64}$/.test(destAddr.trim()))}
             onClick={doClaim}>
             {round ? `claim ${round.amount} PCO` : 'claim'}
           </button>

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -35,6 +35,8 @@ export default function TokenApp() {
   const [status, setStatus] = useState<Status>(null);
   const [busy, setBusy] = useState(false);
   const [vkActive, setVkActive] = useState(false);
+  // A ref mirror of destAddr: refresh needs to READ it without DEPENDING on it.
+  const destAddrRef = useRef('');
   const [vkHot, setVkHot] = useState('');
   const [vkCold, setVkCold] = useState('');          // cold account the connected wallet votes for
   const [voteMode, setVoteMode] = useState<'wallet' | 'hotkey'>('wallet');
@@ -91,8 +93,12 @@ export default function TokenApp() {
         setWalletBal(0); setWalletKda(0); setVkActive(false); setMyBallots({}); setClaimed(false);
         return;
       }
-      const effDest = destEdited ? destAddr.trim() : w.account;
-      if (!destEdited && destAddr !== w.account) setDestAddr(w.account);
+      const effDest = destEdited ? destAddrRef.current.trim() : w.account;
+      // Functional update so `destAddr` does NOT have to be a dependency of
+      // refresh. It used to be, and refresh SETS it — so every refresh recreated
+      // refresh, which re-ran the effect. It settled after one extra cycle, but
+      // it is a cascade and the linter is right to call it one.
+      if (!destEdited) setDestAddr((prev) => (prev === w.account ? prev : w.account));
       setClaimed(sel && /^k:[0-9a-f]{64}$/.test(effDest) ? await alreadyClaimed(sel.id, effDest) : false);
       setWalletBal(await balance(w.account));
       setWalletKda(await kdaBalance(w.account));
@@ -105,12 +111,25 @@ export default function TokenApp() {
     } catch (e) {
       say(`Cannot reach the network: ${(e as Error).message}`, 'err');
     }
-  }, [roundId, wallet, destEdited, destAddr]);
+  }, [roundId, wallet, destEdited]);
 
   // refresh is re-created whenever key/roundId/wallet change (its useCallback
   // deps), so this effect re-runs with FRESH state — no manual refresh() calls
   // in onChange handlers (they would run a stale closure).
-  useEffect(() => { void refresh(); const t = setInterval(() => { void refresh(); }, 30000); return () => clearInterval(t); }, [refresh]);
+  // refresh() sets state, so calling it synchronously in the effect body is a
+  // cascading render by definition. Defer the first run to a microtask-ish tick:
+  // same behaviour to a user, but the effect body itself no longer sets state.
+  useEffect(() => {
+    let live = true;
+    const tick = () => { if (live) void refresh(); };
+    const first = setTimeout(tick, 0);
+    const every = setInterval(tick, 30000);
+    return () => { live = false; clearTimeout(first); clearInterval(every); };
+  }, [refresh]);
+
+  // Keep the ref in step with the state it mirrors. Cheap, and it means refresh
+  // always reads the current value without listing it as a dependency.
+  useEffect(() => { destAddrRef.current = destAddr; }, [destAddr]);
 
   const selectedRound = () => rounds.find((r) => r.id === roundId) ?? rounds[0];
 

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -4,22 +4,21 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from '@/styles/token.module.css';
 import { CFG } from '@/lib/chain';
 import {
-  loadOrCreateLocalKey, saveLocalKey, openRounds, alreadyClaimed, poolBalance, masterOpen,
+  openRounds, alreadyClaimed, poolBalance, masterOpen,
   balance, openProposals, myBallot, claim, transfer, vote,
   voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance,
   type Round, type Proposal, checkCode } from '@/lib/pco';
 import {
-  connectEcko, connectZelcore, connectLedger, connectLocalKey, eckoAvailable,
-  type ConnectedWallet, type LocalAccount,
+  connectEcko, connectZelcore, connectLedger, eckoAvailable,
+  type ConnectedWallet,
 } from '@/lib/wallets';
 
 type Status = { msg: string; kind: 'info' | 'ok' | 'err' } | null;
 
 // ONE active wallet at a time drives the whole page: the claim destination,
-// balances, votes, transfers. The in-browser key is simply the default wallet
+// balances, votes, transfers. There is no default wallet: the page generates
 // (zero setup), and switching to Ledger/Ecko/Zelcore REPLACES it everywhere.
 export default function TokenApp() {
-  const [key, setKey] = useState<LocalAccount | null>(null);
   const [rounds, setRounds] = useState<Round[]>([]);
   const [roundId, setRoundId] = useState('');
   const [code, setCode] = useState('');
@@ -36,7 +35,8 @@ export default function TokenApp() {
   const [status, setStatus] = useState<Status>(null);
   const [busy, setBusy] = useState(false);
   const [vkActive, setVkActive] = useState(false);
-  const [vkCold, setVkCold] = useState('');          // cold account this browser's key votes for
+  const [vkHot, setVkHot] = useState('');
+  const [vkCold, setVkCold] = useState('');          // cold account the connected wallet votes for
   const [voteMode, setVoteMode] = useState<'wallet' | 'hotkey'>('wallet');
   const [walletKda, setWalletKda] = useState(0);
   const [destAddr, setDestAddr] = useState('');
@@ -45,17 +45,15 @@ export default function TokenApp() {
   const [rotKey, setRotKey] = useState('');
   const [lookup, setLookup] = useState('');
   const [lookupResult, setLookupResult] = useState<{ label: string; total?: number; perChain?: { chain: string; balance: number }[] } | null>(null);
-  const fileRef = useRef<HTMLInputElement>(null);
 
   const say = (msg: string, kind: Status extends null ? never : 'info' | 'ok' | 'err' = 'info') => setStatus({ msg, kind });
 
   const refresh = useCallback(async () => {
     try {
-      let k = key;
-      let w = wallet;
-      if (!k) { k = loadOrCreateLocalKey(); setKey(k); }
-      // the DEFAULT active wallet is the in-browser key — one identity, always
-      if (!w) { w = connectLocalKey(k); setWallet(w); }
+      // There is no default wallet any more: the page generates no keys, so
+      // until the user connects one there is no identity to read balances for.
+      // Round and pool state are public and load regardless.
+      const w = wallet;
       const [op, pl, rs, props] = await Promise.all([
         masterOpen(), poolBalance(), openRounds(), openProposals(),
       ]);
@@ -67,6 +65,11 @@ export default function TokenApp() {
       // the RECEIVING ADDRESS is an open field: it follows the active wallet
       // until the user types their own (e.g. a hardware wallet in a safe —
       // paste the public address and claim, nothing signs)
+      if (!w) {
+        // no wallet connected: show the public state, clear anything account-shaped
+        setWalletBal(0); setWalletKda(0); setVkActive(false); setMyBallots({}); setClaimed(false);
+        return;
+      }
       const effDest = destEdited ? destAddr.trim() : w.account;
       if (!destEdited && destAddr !== w.account) setDestAddr(w.account);
       setClaimed(sel && /^k:[0-9a-f]{64}$/.test(effDest) ? await alreadyClaimed(sel.id, effDest) : false);
@@ -81,7 +84,7 @@ export default function TokenApp() {
     } catch (e) {
       say(`Cannot reach the network: ${(e as Error).message}`, 'err');
     }
-  }, [key, roundId, wallet, destEdited, destAddr]);
+  }, [roundId, wallet, destEdited, destAddr]);
 
   // refresh is re-created whenever key/roundId/wallet change (its useCallback
   // deps), so this effect re-runs with FRESH state — no manual refresh() calls
@@ -91,13 +94,13 @@ export default function TokenApp() {
   const selectedRound = () => rounds.find((r) => r.id === roundId) ?? rounds[0];
 
   const doClaim = async () => {
-    const round = selectedRound(); const k = key!;
+    const round = selectedRound();
     if (!wallet) return say('Choose your wallet first (step 1).', 'err');
     if (!round) return say('No open round right now.', 'err');
     if (!code.trim()) return say('Enter the engagement code first.', 'err');
     // destination = the active wallet, OR a pasted k: address. No destination
     // signature is needed — claims have no claimer signature by design; the
-    // browser key only signs the station's GAS_PAYER capability.
+    // the wallet only signs the station's GAS_PAYER capability.
     const a = (destEdited ? destAddr.trim() : wallet.account);
     if (!/^k:[0-9a-f]{64}$/.test(a)) return say('That is not a valid k: account — expected "k:" + 64 lowercase hex characters. Check for typos before claiming.', 'err');
     const dest = { account: a, publicKey: a.slice(2) };
@@ -110,26 +113,25 @@ export default function TokenApp() {
       return say("That answer doesn't match this round — nothing was submitted, so try again freely.", 'err');
     }
     setBusy(true); say(`Claiming "${round.id}" to ${destLabel} (the gas station pays the fee)…`);
-    try { await claim(round, dest, k, code.trim().toLowerCase()); say(`Claimed ${round.amount} PCO to ${dest.account.slice(0, 14)}…!`, 'ok'); setCode(''); }
+    try { await claim(round, dest, wallet, code.trim().toLowerCase()); say(`Claimed ${round.amount} PCO to ${dest.account.slice(0, 14)}…!`, 'ok'); setCode(''); }
     catch (e) { say(`Claim failed: ${(e as Error).message}`, 'err'); }
     setBusy(false); void refresh();
   };
 
   // Switching wallets REPLACES the active identity everywhere — never two at
-  // once. A failed or ended external session falls back to the in-browser key.
-  const fallback = () => connectLocalKey(key ?? loadOrCreateLocalKey());
-  const connect = async (kind: 'ecko' | 'zelcore' | 'ledger' | 'localkey') => {
+  // once. A failed or ended session leaves the page with no wallet, not a fallback.
+  const connect = async (kind: 'ecko' | 'zelcore' | 'ledger') => {
     say(`Connecting ${kind}…`);
     wallet?.disconnect?.();
     try {
       let w: ConnectedWallet;
-      if (kind === 'ecko') w = await connectEcko((reason) => { setWallet(fallback()); say(`${reason} — switched back to the in-browser key`, 'err'); });
+      if (kind === 'ecko') w = await connectEcko((reason) => { setWallet(null); say(`${reason} — wallet disconnected`, 'err'); });
       else if (kind === 'zelcore') w = await connectZelcore();
       else if (kind === 'ledger') w = await connectLedger();
-      else w = fallback();
+      else return say('Unknown wallet type.', 'err');
       setWallet(w); say(`Active wallet: ${w.label} · ${w.account.slice(0, 16)}…`, 'ok');
     } catch (e) {
-      setWallet(fallback());
+      setWallet(null);
       say(`${(e as Error).message}`, 'err');
     }
   };
@@ -153,11 +155,13 @@ export default function TokenApp() {
   const doVote = async (pid: string) => {
     const ranking = rankings[pid] ?? [];
     if (ranking.length === 0) return say('Build your ranking first — tap the options in order of preference.', 'err');
-    if (voteMode === 'hotkey' && vkCold && key) {
-      // the browser key is a registered VOTE KEY for the cold account: it signs
-      // and pays its own gas; the cold wallet never comes out for voting
-      setBusy(true); say(`Submitting the ranked ballot as ${vkCold.slice(0, 14)}… with the browser vote key…`);
-      try { await voteAs(connectLocalKey(key), vkCold, pid, ranking); say('Ballot submitted as the cold account (vote key signed).', 'ok'); }
+    if (voteMode === 'hotkey' && vkCold && wallet) {
+      // the CONNECTED wallet is a registered VOTE KEY for the cold account: it
+      // signs and pays its own gas, so the cold wallet never comes out to vote.
+      // This used to be a key the page generated for you; registering a wallet
+      // you already control is the same mechanism without us minting secrets.
+      setBusy(true); say(`Submitting the ranked ballot as ${vkCold.slice(0, 14)}… with the registered vote key…`);
+      try { await voteAs(wallet, vkCold, pid, ranking); say('Ballot submitted as the cold account (vote key signed).', 'ok'); }
       catch (e) { say(`Vote-key ballot failed: ${(e as Error).message}`, 'err'); }
       setBusy(false); void refresh(); return;
     }
@@ -169,10 +173,14 @@ export default function TokenApp() {
   };
 
   const doRegisterVoteKey = async () => {
-    if (!wallet || !key) return say('Connect your main wallet first.', 'err');
-    setBusy(true); say("Registering this browser's key as your vote key (your wallet signs)…");
+    if (!wallet) return say('Connect your main wallet first.', 'err');
+    const hot = vkHot.trim();
+    // A vote key is ANOTHER ACCOUNT YOU CONTROL, identified by its PUBLIC key.
+    // The page never sees a secret: the hot account signs its own ballots later.
+    if (!/^[0-9a-f]{64}$/.test(hot)) return say('Enter the vote key\u2019s PUBLIC key (64 hex) — the account you want to vote with. Never paste a private key.', 'err');
+    setBusy(true); say('Registering that public key as your vote key (your wallet signs)…');
     try {
-      await setVoteKey(wallet, key.publicKey);
+      await setVoteKey(wallet, hot);
       localStorage.setItem('pco-votekey-cold', wallet.account);
       say('Vote key registered — this browser can now vote for your account (and ONLY vote).', 'ok');
     } catch (e) { say(`Registration failed: ${(e as Error).message}`, 'err'); }
@@ -216,26 +224,6 @@ export default function TokenApp() {
     }
   };
 
-  const backup = () => {
-    if (!key) return;
-    const blob = new Blob([JSON.stringify(key, null, 2)], { type: 'application/json' });
-    const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = `pco-key-${CFG.networkId}.json`; a.click();
-  };
-  const restore = () => fileRef.current?.click();
-  const onRestore = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0]; if (!f) return;
-    const r = new FileReader();
-    r.onload = () => {
-      try {
-        const j = JSON.parse(String(r.result));
-        if (!/^[0-9a-f]{64}$/.test(j.secretKey) || !/^[0-9a-f]{64}$/.test(j.publicKey)) throw new Error('not a PCO key backup');
-        const acct: LocalAccount = { account: `k:${j.publicKey}`, publicKey: j.publicKey, secretKey: j.secretKey };
-        saveLocalKey(acct); setKey(acct); say(`Restored ${acct.account.slice(0, 14)}…`, 'ok'); void refresh();
-      } catch (err) { say(`Could not restore: ${(err as Error).message}`, 'err'); }
-      if (fileRef.current) fileRef.current.value = '';
-    };
-    r.readAsText(f);
-  };
 
   const round = selectedRound();
 
@@ -248,13 +236,11 @@ export default function TokenApp() {
         <h2>1 · Choose your wallet</h2>
         <p className={styles.muted}>
           Everything on this page — claiming, balances, votes, transfers — uses <b>one active
-          wallet</b>. The in-browser key needs no setup (perfect for a first claim); switch to your
-          own wallet at any time and the page follows it.
+          wallet</b>: your own. Connect it and the page follows it.
+          {' '}<b>Claiming stays gasless</b> — you need no KDA to claim; your wallet only
+          authorises the gas station to pay, and the station covers the fee.
         </p>
         <p className={styles.walletButtons}>
-          <button className={styles.btn} disabled={wallet?.kind === 'localkey'} onClick={() => connect('localkey')}>
-            in-browser key{wallet?.kind === 'localkey' && ' ✓'}
-          </button>
           <button className={styles.btn} disabled={!eckoAvailable() || wallet?.kind === 'ecko'} onClick={() => connect('ecko')}>
             EckoWallet{!eckoAvailable() ? ' (not detected)' : wallet?.kind === 'ecko' ? ' ✓' : ''}
           </button>
@@ -279,44 +265,30 @@ export default function TokenApp() {
               Holds on <b>chain {CFG.chain}</b>: <b>{walletBal.toLocaleString()} PCO</b> · <b>{walletKda.toLocaleString(undefined, { maximumFractionDigits: 4 })} KDA</b>
               {walletKda < 0.05 && <span className={styles.muted}> — self-paid actions (transfer/vote) need a little KDA <i>on this chain</i>; claiming does not. KDA held on another Kadena chain has to be moved here first.</span>}
             </p>
-            {wallet.kind === 'localkey' && (
-              <>
-                <p className={styles.muted}>
-                  <b>This key lives only in this browser.</b> Keep the backup — clearing storage deletes it.
-                  <button className={styles.btn} onClick={backup}>download key backup</button>
-                  <button className={styles.btn} onClick={restore}>restore from backup</button>
-                  <input ref={fileRef} type="file" accept="application/json" hidden onChange={onRestore} />
-                </p>
-                  {/* There was a "paste a secret key here" field. It is gone, and
-                      nothing like it should return. A text box asking for private key
-                      material is the exact shape of every wallet-drainer phishing page,
-                      and putting one on an official site teaches the habit that gets
-                      people robbed on a fake one. Restoring from a backup file this
-                      page itself produced is a different act and stays. */}
-                  <p className={styles.muted}>
-                    <b>PCO will never ask for your seed phrase or a private key.</b> Not here,
-                    not by message, not ever. Anyone asking for one is not us — including a
-                    page that looks exactly like this one.
-                  </p>
-              </>
-            )}
-            {wallet.kind !== 'localkey' && (
-              <>
-                <hr />
-                <h3>Voting key {vkActive ? '— active' : '— none registered'}</h3>
-                <p className={styles.muted}>
-                  Register this browser&apos;s key as a dedicated <b>vote key</b> for this account: it
-                  can then vote on your behalf while your {wallet.label} stays cold. The vote key can{' '}
-                  <b>only vote</b> — it can never transfer, rotate, or re-point itself, and your main
-                  wallet always keeps its own voting power. <a href="/token/guide#voting-key">How this works →</a>
-                </p>
-                <p>
-                  {!vkActive
-                    ? <button className={styles.btn} disabled={busy} onClick={doRegisterVoteKey}>register browser key as vote key</button>
-                    : <button className={styles.btn} disabled={busy} onClick={doClearVoteKey}>clear vote key</button>}
-                </p>
-              </>
-            )}
+            <>
+              <hr />
+              <h3>Voting key {vkActive ? '— active' : '— none registered'}</h3>
+              <p className={styles.muted}>
+                Nominate <b>another account you control</b> as a dedicated <b>vote key</b> for this
+                one: it can then vote on your behalf while your {wallet.label} stays cold. The vote
+                key can <b>only vote</b> — it can never transfer, rotate, or re-point itself, and
+                your main wallet always keeps its own voting power.{' '}
+                <a href="/token/guide#voting-key">How this works →</a>
+              </p>
+              <p className={styles.muted}>
+                Identify it by its <b>public key</b> (64 hex). Nothing secret is entered here, and
+                nothing about the other account is stored — it signs its own ballots later.
+              </p>
+              <p>
+                {!vkActive
+                  ? <>
+                      <input placeholder="vote key PUBLIC key (64 hex)" value={vkHot}
+                             onChange={(e) => setVkHot(e.target.value)} style={{ width: '60%' }} />
+                      <button className={styles.btn} disabled={busy || !vkHot.trim()} onClick={doRegisterVoteKey}>register vote key</button>
+                    </>
+                  : <button className={styles.btn} disabled={busy} onClick={doClearVoteKey}>clear vote key</button>}
+              </p>
+            </>
           </>
         )}
       </section>

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -48,6 +48,27 @@ export default function TokenApp() {
 
   const say = (msg: string, kind: Status extends null ? never : 'info' | 'ok' | 'err' = 'info') => setStatus({ msg, kind });
 
+  // ECKO DETECTION MUST NOT HAPPEN DURING RENDER.
+  //
+  // eckoAvailable() reads window, so the server renders "not detected / disabled"
+  // and a client with the extension renders "enabled" — a hydration mismatch that
+  // React explicitly does NOT patch up for attributes. The server's disabled=""
+  // could therefore stick, leaving the Ecko button permanently unclickable for
+  // exactly the users who have Ecko. (Pre-existing; it has been live since launch.)
+  //
+  // null = still detecting, which is what BOTH the server and the first client
+  // render produce, so they agree. The extension also injects asynchronously, so
+  // one check on mount can miss it — re-check for a couple of seconds.
+  const [eckoReady, setEckoReady] = useState<boolean | null>(null);
+  useEffect(() => {
+    let done = false;
+    const check = () => { if (!done && eckoAvailable()) { setEckoReady(true); done = true; } };
+    check();
+    const timers = [200, 600, 1200, 2000].map((ms) => setTimeout(check, ms));
+    const settle = setTimeout(() => { if (!done) setEckoReady(false); }, 2200);
+    return () => { done = true; timers.forEach(clearTimeout); clearTimeout(settle); };
+  }, []);
+
   // DEV-ONLY signing probe. Lets a real wallet sign the real claim transaction
   // and verify the signature, without submitting — the one risk that typecheck
   // and build cannot cover. Stripped from any production build by the guard.
@@ -262,8 +283,8 @@ export default function TokenApp() {
           authorises the gas station to pay, and the station covers the fee.
         </p>
         <p className={styles.walletButtons}>
-          <button className={styles.btn} disabled={!eckoAvailable() || wallet?.kind === 'ecko'} onClick={() => connect('ecko')}>
-            EckoWallet{!eckoAvailable() ? ' (not detected)' : wallet?.kind === 'ecko' ? ' ✓' : ''}
+          <button className={styles.btn} disabled={eckoReady !== true || wallet?.kind === 'ecko'} onClick={() => connect('ecko')}>
+            EckoWallet{eckoReady === null ? ' (checking…)' : eckoReady === false ? ' (not detected)' : wallet?.kind === 'ecko' ? ' ✓' : ''}
           </button>
           <button className={styles.btn} disabled={wallet?.kind === 'zelcore'} onClick={() => connect('zelcore')}>
             Zelcore{wallet?.kind === 'zelcore' && ' ✓'}

--- a/src/components/token/TokenPage.tsx
+++ b/src/components/token/TokenPage.tsx
@@ -32,13 +32,15 @@ export default function TokenPage() {
         <ul>
           <li>
             <b>Step 1 — choose your wallet.</b> One active wallet drives everything on the page:
-            claims land there, balances show for it, votes and transfers come from it. The in-browser
-            key needs zero setup (perfect for a first claim); or pick EckoWallet, Zelcore, or a
-            Ledger. Never two identities at once — switching wallets switches everything.
+            claims land there, balances show for it, votes and transfers come from it. Connect
+            EckoWallet, Zelcore, or a Ledger — a wallet you already control. This page never
+            generates or stores keys for you. Never two identities at once — switching wallets
+            switches everything.
           </li>
           <li>
-            <b>Step 2 — claim, free.</b> The on-chain gas station pays the claim fee and your wallet
-            never signs for it — claiming is free with any wallet. Everything else (transfers,
+            <b>Step 2 — claim, free.</b> The on-chain gas station pays the claim fee, so you need
+            no KDA to claim. Your wallet signs one thing: permission for the station to pay — never a
+            movement of your own funds. Everything else (transfers,
             ranked-choice voting) is <i>not</i> sponsored: your active wallet signs and pays
             ordinary gas. On-chain questions are admin-authored — suggest yours on the public
             channels and the organization makes it official.

--- a/src/lib/chain.ts
+++ b/src/lib/chain.ts
@@ -58,6 +58,39 @@ const b64urlBytes = (hashB64: string): Uint8Array => {
   return Uint8Array.from(atob(pad), (c) => c.charCodeAt(0));
 };
 
+/**
+ * EPHEMERAL GAS-STATION SIGNER — in memory, one per page load, never persisted.
+ *
+ * A sponsored transaction still needs A signer: the node grants the station's
+ * GAS_PAYER capability by scanning the signers' capability lists, so if nobody
+ * declares it the station's guard never opens. But that signer does not have to
+ * be the user — it authorises the station to pay a fee and nothing else, so any
+ * throwaway key does.
+ *
+ * This is why a claim asks the user for NOTHING: no wallet popup, no device, no
+ * KDA. They type an answer and click.
+ *
+ * What it deliberately is not:
+ *   - not written to localStorage, so clearing storage loses nothing
+ *   - not exported, downloadable, or importable, so there is no backup to lose
+ *     and no field for a phishing clone to imitate
+ *   - not an identity: it never receives, holds, or moves tokens, and it is a
+ *     different key on every page load
+ *
+ * (PCO previously used a PERSISTED browser key for this, which is what created
+ * the backup/restore/import surface. Same mechanism, without the liability.)
+ */
+let _ephemeral: { publicKey: string; secretKey: string } | null = null;
+export function ephemeralGasSigner(): { publicKey: string; secretKey: string } {
+  // Lazy, so it is never generated during SSR — where it would be pointless and
+  // would differ from the client's.
+  if (!_ephemeral) {
+    const sk = ed25519.utils.randomPrivateKey();
+    _ephemeral = { secretKey: bytesToHex(sk), publicKey: bytesToHex(ed25519.getPublicKey(sk)) };
+  }
+  return _ephemeral;
+}
+
 export function signHash(hashB64: string, privHex: string): string {
   return bytesToHex(ed25519.sign(b64urlBytes(hashB64), hexToBytes(privHex)));
 }

--- a/src/lib/pco.ts
+++ b/src/lib/pco.ts
@@ -137,6 +137,42 @@ export function checkCode(round: Round, raw: string): boolean {
  * `dest` may be any k: account — claims carry NO claimer signature by design, so
  * tokens can only land in the account canonically bound to the supplied guard.
  */
+/**
+ * DEV-ONLY: prove a wallet will sign the sponsored claim shape, WITHOUT claiming.
+ *
+ * The one thing that cannot be checked by typecheck or build is whether each
+ * wallet adapter signs a transaction whose SENDER is the gas station rather than
+ * itself. That is the sponsored shape, it is normal, and walletSign is
+ * sender-agnostic — but "should work" is not evidence, and the claim path is the
+ * one every user takes on a launched token.
+ *
+ * This builds the byte-identical transaction `claim()` would build, asks the
+ * wallet to sign it, verifies the signature covers that exact hash under the
+ * wallet's own key, and then throws it away. Nothing is submitted, no claim slot
+ * is consumed, no gas is spent, and the round is untouched.
+ *
+ * Exposed on window only in development (see TokenApp); `next build` sets
+ * NODE_ENV=production, so it cannot reach the deployed site.
+ */
+export async function dryRunClaimSignature(
+  round: Round, dest: { account: string; publicKey: string }, signer: ConnectedWallet, code: string,
+): Promise<{ ok: true; hash: string; sig: string; station: string }> {
+  const submitted = normalizeCode(code);
+  const station = await stationAccount();
+  const gasPayerCap = { name: `${G}.GAS_PAYER`, args: ['web', { int: 6000 }, { decimal: '0.0000001' }] };
+  const { cmd, hash } = buildExec({
+    code: `(${C}.claim "${round.id}" "${dest.account}" (read-keyset 'ks) "${submitted}")`,
+    data: { ks: { keys: [dest.publicKey], pred: 'keys-all' } },
+    sender: station,
+    signers: [{ pubKey: signer.publicKey, caps: [gasPayerCap] }],
+    gasLimit: 6000, gasPrice: 1e-8,
+  });
+  // walletSign throws if the returned signature does not cover this hash under
+  // the wallet's key, so reaching the end IS the proof.
+  const signed = await walletSign(signer, { cmd, hash }, [gasPayerCap]);
+  return { ok: true, hash, sig: signed.sigs[0].sig, station };
+}
+
 export async function claim(round: Round, dest: { account: string; publicKey: string }, signer: ConnectedWallet, code: string): Promise<Record<string, unknown>> {
   // Refuse locally before building anything. See checkCode().
   if (!checkCode(round, code)) {

--- a/src/lib/pco.ts
+++ b/src/lib/pco.ts
@@ -1,13 +1,13 @@
 // pco.ts — the PCO token actions for the page.
 //
-//   claim   — GASLESS: the on-chain gas station pays (station-sponsored, the
-//             ONLY sponsored action). Signed by the connected wallet, which
-//             authorises the station and needs no KDA of its own.
+//   claim   — GASLESS and SIGNATURE-FREE for the user: the on-chain gas station
+//             pays (the ONLY sponsored action), authorised by an ephemeral
+//             in-memory key. No wallet prompt, no device, no KDA.
 //   others  — SELF-PAID: transfer / cross-chain / vote / vote-key / rotate. Signed
 //             by the connected wallet, which pays its own coin.GAS. (Proposals are
 //             ADMIN-AUTHORED — PROPOSAL-OPS gates create/cancel to the gov or ops
 //             keyset — so this library deliberately exposes no propose path.)
-import { CFG, T, C, G, CHAINS, local, localOn, buildExec, submitAndPoll, cmdHash, pactHash, signHash } from './chain';
+import { CFG, T, C, G, CHAINS, local, localOn, buildExec, submitAndPoll, cmdHash, pactHash, signHash, ephemeralGasSigner } from './chain';
 import { walletSign, type ConnectedWallet } from './wallets';
 
 // ---------- reads ----------
@@ -87,11 +87,7 @@ export async function myBallot(pid: string, account: string): Promise<{ ranking:
   return { ranking: ((r.ranking as unknown[]) ?? []).map(dec), weight: dec(r.weight) };
 }
 
-// ---------- claim (GASLESS, station-sponsored) ----------
-// dest may be the browser key OR any k: account (e.g. the connected wallet):
-// claims need NO signature from the claimer by design — tokens can only land
-// in the account canonically bound to the supplied guard. The browser key
-// signs only the station's GAS_PAYER capability.
+// ---------- claim (GASLESS, station-sponsored, no user signature) ----------
 /** Normalize an answer the way the round's code hash was computed: trim, lowercase. */
 export function normalizeCode(raw: string): string {
   return raw.trim().toLowerCase();
@@ -124,56 +120,30 @@ export function checkCode(round: Round, raw: string): boolean {
 }
 
 /**
- * Claim a round. GASLESS: the station pays the gas — the wallet only AUTHORISES
- * that by signing the station's GAS_PAYER capability. The signer therefore needs
- * no KDA of its own, which is the whole point of sponsored onboarding.
+ * Claim a round. THE USER SIGNS NOTHING.
  *
- * The signer is the connected EXTERNAL wallet (2026-08-01). It used to be a key
- * this page generated and stored in localStorage; that was a testing affordance
- * and it is gone. A site that mints private keys for you, keeps them in browser
- * storage, and asks you to back them up is teaching a habit that does not
- * survive contact with a phishing clone of itself.
+ * Claims carry no claimer signature by design: tokens can only land in the
+ * account canonically bound to the guard supplied with the claim, so proving who
+ * you are is unnecessary. What the transaction DOES need is a signer declaring
+ * the station's GAS_PAYER capability — that is how the node knows to open the
+ * station's guard and let it pay the fee.
  *
- * `dest` may be any k: account — claims carry NO claimer signature by design, so
- * tokens can only land in the account canonically bound to the supplied guard.
+ * That signer is an EPHEMERAL key held only in memory (see ephemeralGasSigner).
+ * It authorises a fee payment and nothing else, so it does not matter who holds
+ * it, and it is gone when the tab closes.
+ *
+ * Result: no wallet popup, no device, no KDA. Type the answer and click.
+ *
+ * Two other designs were tried on the way here and both were worse. A PERSISTED
+ * browser key did the same job but had to be backed up, restored and imported —
+ * which is exactly the surface a phishing clone imitates. Making the connected
+ * wallet sign removed that surface but put a prompt in front of every claim, for
+ * a signature that only ever said "the station may pay this fee".
+ *
+ * `dest` may be any k: account: the connected wallet, or an address pasted from
+ * a hardware wallet that never comes online.
  */
-/**
- * DEV-ONLY: prove a wallet will sign the sponsored claim shape, WITHOUT claiming.
- *
- * The one thing that cannot be checked by typecheck or build is whether each
- * wallet adapter signs a transaction whose SENDER is the gas station rather than
- * itself. That is the sponsored shape, it is normal, and walletSign is
- * sender-agnostic — but "should work" is not evidence, and the claim path is the
- * one every user takes on a launched token.
- *
- * This builds the byte-identical transaction `claim()` would build, asks the
- * wallet to sign it, verifies the signature covers that exact hash under the
- * wallet's own key, and then throws it away. Nothing is submitted, no claim slot
- * is consumed, no gas is spent, and the round is untouched.
- *
- * Exposed on window only in development (see TokenApp); `next build` sets
- * NODE_ENV=production, so it cannot reach the deployed site.
- */
-export async function dryRunClaimSignature(
-  round: Round, dest: { account: string; publicKey: string }, signer: ConnectedWallet, code: string,
-): Promise<{ ok: true; hash: string; sig: string; station: string }> {
-  const submitted = normalizeCode(code);
-  const station = await stationAccount();
-  const gasPayerCap = { name: `${G}.GAS_PAYER`, args: ['web', { int: 6000 }, { decimal: '0.0000001' }] };
-  const { cmd, hash } = buildExec({
-    code: `(${C}.claim "${round.id}" "${dest.account}" (read-keyset 'ks) "${submitted}")`,
-    data: { ks: { keys: [dest.publicKey], pred: 'keys-all' } },
-    sender: station,
-    signers: [{ pubKey: signer.publicKey, caps: [gasPayerCap] }],
-    gasLimit: 6000, gasPrice: 1e-8,
-  });
-  // walletSign throws if the returned signature does not cover this hash under
-  // the wallet's key, so reaching the end IS the proof.
-  const signed = await walletSign(signer, { cmd, hash }, [gasPayerCap]);
-  return { ok: true, hash, sig: signed.sigs[0].sig, station };
-}
-
-export async function claim(round: Round, dest: { account: string; publicKey: string }, signer: ConnectedWallet, code: string): Promise<Record<string, unknown>> {
+export async function claim(round: Round, dest: { account: string; publicKey: string }, code: string): Promise<Record<string, unknown>> {
   // Refuse locally before building anything. See checkCode().
   if (!checkCode(round, code)) {
     throw new Error("That answer doesn't match this round. Check it and try again — nothing was submitted.");
@@ -186,20 +156,15 @@ export async function claim(round: Round, dest: { account: string; publicKey: st
   // matched.
   const submitted = normalizeCode(code);
   const station = await stationAccount();
-  const gasPayerCap = { name: `${G}.GAS_PAYER`, args: ['web', { int: 6000 }, { decimal: '0.0000001' }] };
+  const eph = ephemeralGasSigner();
   const { cmd, hash } = buildExec({
     code: `(${C}.claim "${round.id}" "${dest.account}" (read-keyset 'ks) "${submitted}")`,
     data: { ks: { keys: [dest.publicKey], pred: 'keys-all' } },
     sender: station,
-    signers: [{ pubKey: signer.publicKey, caps: [gasPayerCap] }],
+    signers: [{ pubKey: eph.publicKey, caps: [{ name: `${G}.GAS_PAYER`, args: ['web', { int: 6000 }, { decimal: '0.0000001' }] }] }],
     gasLimit: 6000, gasPrice: 1e-8,
   });
-  // The wallet signs a transaction whose SENDER is the station, not itself. That
-  // is the sponsored shape and it is normal; walletSign verifies the returned
-  // signature covers this exact hash under the wallet's own key before anything
-  // is submitted.
-  const signed = await walletSign(signer, { cmd, hash }, [gasPayerCap]);
-  return submitAndPoll(signed);
+  return submitAndPoll({ cmd, hash, sigs: [{ sig: signHash(hash, eph.secretKey) }] });
 }
 
 export async function kdaBalance(account: string): Promise<number> {

--- a/src/lib/pco.ts
+++ b/src/lib/pco.ts
@@ -1,13 +1,14 @@
 // pco.ts — the PCO token actions for the page.
 //
 //   claim   — GASLESS: the on-chain gas station pays (station-sponsored, the
-//             ONLY sponsored action). Signed by the in-browser throwaway key.
+//             ONLY sponsored action). Signed by the connected wallet, which
+//             authorises the station and needs no KDA of its own.
 //   others  — SELF-PAID: transfer / cross-chain / vote / vote-key / rotate. Signed
 //             by the connected wallet, which pays its own coin.GAS. (Proposals are
 //             ADMIN-AUTHORED — PROPOSAL-OPS gates create/cancel to the gov or ops
 //             keyset — so this library deliberately exposes no propose path.)
 import { CFG, T, C, G, CHAINS, local, localOn, buildExec, submitAndPoll, cmdHash, pactHash, signHash } from './chain';
-import { walletSign, type ConnectedWallet, type LocalAccount } from './wallets';
+import { walletSign, type ConnectedWallet } from './wallets';
 
 // ---------- reads ----------
 export type Round = { id: string; amount: number; budget: number; claimed: number; opens: string; closes: string; active: boolean; codeHash: string };
@@ -122,7 +123,21 @@ export function checkCode(round: Round, raw: string): boolean {
   return pactHash(normalizeCode(raw)) === round.codeHash;
 }
 
-export async function claim(round: Round, dest: { account: string; publicKey: string }, signer: LocalAccount, code: string): Promise<Record<string, unknown>> {
+/**
+ * Claim a round. GASLESS: the station pays the gas — the wallet only AUTHORISES
+ * that by signing the station's GAS_PAYER capability. The signer therefore needs
+ * no KDA of its own, which is the whole point of sponsored onboarding.
+ *
+ * The signer is the connected EXTERNAL wallet (2026-08-01). It used to be a key
+ * this page generated and stored in localStorage; that was a testing affordance
+ * and it is gone. A site that mints private keys for you, keeps them in browser
+ * storage, and asks you to back them up is teaching a habit that does not
+ * survive contact with a phishing clone of itself.
+ *
+ * `dest` may be any k: account — claims carry NO claimer signature by design, so
+ * tokens can only land in the account canonically bound to the supplied guard.
+ */
+export async function claim(round: Round, dest: { account: string; publicKey: string }, signer: ConnectedWallet, code: string): Promise<Record<string, unknown>> {
   // Refuse locally before building anything. See checkCode().
   if (!checkCode(round, code)) {
     throw new Error("That answer doesn't match this round. Check it and try again — nothing was submitted.");
@@ -135,14 +150,20 @@ export async function claim(round: Round, dest: { account: string; publicKey: st
   // matched.
   const submitted = normalizeCode(code);
   const station = await stationAccount();
+  const gasPayerCap = { name: `${G}.GAS_PAYER`, args: ['web', { int: 6000 }, { decimal: '0.0000001' }] };
   const { cmd, hash } = buildExec({
     code: `(${C}.claim "${round.id}" "${dest.account}" (read-keyset 'ks) "${submitted}")`,
     data: { ks: { keys: [dest.publicKey], pred: 'keys-all' } },
     sender: station,
-    signers: [{ pubKey: signer.publicKey, caps: [{ name: `${G}.GAS_PAYER`, args: ['web', { int: 6000 }, { decimal: '0.0000001' }] }] }],
+    signers: [{ pubKey: signer.publicKey, caps: [gasPayerCap] }],
     gasLimit: 6000, gasPrice: 1e-8,
   });
-  return submitAndPoll({ cmd, hash, sigs: [{ sig: signHash(hash, signer.secretKey) }] });
+  // The wallet signs a transaction whose SENDER is the station, not itself. That
+  // is the sponsored shape and it is normal; walletSign verifies the returned
+  // signature covers this exact hash under the wallet's own key before anything
+  // is submitted.
+  const signed = await walletSign(signer, { cmd, hash }, [gasPayerCap]);
+  return submitAndPoll(signed);
 }
 
 export async function kdaBalance(account: string): Promise<number> {
@@ -238,27 +259,9 @@ export async function lookupAllChains(account: string): Promise<{ total: number;
   return { total: perChain.reduce((s, b) => s + b.balance, 0), perChain };
 }
 
-// ---------- in-browser test key (localStorage; the gasless-claim identity) ----------
 // Namespaced by network: a devnet preview key has no meaning on mainnet, and
 // letting them share a slot would silently hand a mainnet user a devnet key.
 const KEY = `pco-key-${CFG.networkId}`;
-export function loadOrCreateLocalKey(): LocalAccount {
-  if (typeof window === 'undefined') return { account: '', publicKey: '', secretKey: '' };
-  const stored = localStorage.getItem(KEY);
-  if (stored) return JSON.parse(stored);
-  // generate via @noble in the browser
-  const priv = Array.from(crypto.getRandomValues(new Uint8Array(32))).map((b) => b.toString(16).padStart(2, '0')).join('');
-  const pub = pubFromPriv(priv);
-  const acct: LocalAccount = { account: `k:${pub}`, publicKey: pub, secretKey: priv };
-  localStorage.setItem(KEY, JSON.stringify(acct));
-  return acct;
-}
-export function saveLocalKey(acct: LocalAccount) {
-  if (typeof window !== 'undefined') localStorage.setItem(KEY, JSON.stringify(acct));
-}
-// Import a raw ed25519 secret key as the in-browser wallet (REPLACES the
-// stored key — the caller must warn the user). Hex case is normalized; the
-// derived public key determines the k: account.
 // importLocalKey was REMOVED (2026-08-01). It backed a "paste a secret key here"
 // field on the token page — the exact shape of a wallet-drainer phishing form.
 // Shipping one on an official site teaches the habit that gets people robbed on

--- a/src/lib/pco.ts
+++ b/src/lib/pco.ts
@@ -260,20 +260,11 @@ export async function lookupAllChains(account: string): Promise<{ total: number;
   return { total: perChain.reduce((s, b) => s + b.balance, 0), perChain };
 }
 
-// Namespaced by network: a devnet preview key has no meaning on mainnet, and
-// letting them share a slot would silently hand a mainnet user a devnet key.
-const KEY = `pco-key-${CFG.networkId}`;
-// importLocalKey was REMOVED (2026-08-01). It backed a "paste a secret key here"
-// field on the token page — the exact shape of a wallet-drainer phishing form.
-// Shipping one on an official site teaches the habit that gets people robbed on
-// a fake one. The browser key is generated here and backed up to a file this
-// page produces; there is no legitimate reason to accept pasted key material.
-// Do not reintroduce it.
-// small helper so pco.ts stays self-contained
-import { ed25519 } from '@noble/curves/ed25519';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
-function pubFromPriv(privHex: string): string {
-  return bytesToHex(ed25519.getPublicKey(hexToBytes(privHex)));
-}
+// The in-browser key, its localStorage slot, its backup/restore and its import
+// path were all REMOVED (2026-08-01). This page does not generate, store,
+// import or sign with private keys of its own. The only key it ever creates is
+// the ephemeral gas-station signer in chain.ts: in memory, authorises a fee and
+// nothing else, gone when the tab closes.
+// Do not reintroduce browser-held key material.
 
 export { CFG, cmdHash };

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -9,7 +9,7 @@
 // buildExec); wallets only contribute signatures over OUR hash. DEVNET PREVIEW:
 // wallets must be pointed at the devnet network — adapters surface honest
 // errors when they are not.
-import { CFG, cmdHash, signHash, verifyHashSig, bytesToHex, type Cap } from './chain';
+import { CFG, cmdHash, verifyHashSig, bytesToHex, type Cap } from './chain';
 import { blake2b } from '@noble/hashes/blake2b';
 
 const NETWORK_ID = CFG.networkId;

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -4,7 +4,6 @@
 //   ecko     — EckoWallet browser extension (injected window.kadena API)
 //   zelcore  — Zelcore desktop app (Kadena signing API on 127.0.0.1:9467)
 //   ledger   — Ledger hardware via WebHID (hash signing, loaded on demand)
-//   localkey — an in-browser throwaway test key (the gasless-claim key)
 //
 // The page keeps OUR command envelope as the single source of truth (chain.ts
 // buildExec); wallets only contribute signatures over OUR hash. DEVNET PREVIEW:
@@ -16,7 +15,7 @@ import { blake2b } from '@noble/hashes/blake2b';
 const NETWORK_ID = CFG.networkId;
 const API_BASE = CFG.host;
 
-export type WalletKind = 'ecko' | 'zelcore' | 'ledger' | 'localkey';
+export type WalletKind = 'ecko' | 'zelcore' | 'ledger';
 
 export type ConnectedWallet = {
   kind: WalletKind;
@@ -259,14 +258,12 @@ async function confirmBlindSign(): Promise<boolean> {
   );
 }
 
-// ---------------- In-browser test key (the gasless-claim key) ----------------
-export type LocalAccount = { account: string; publicKey: string; secretKey: string };
-export function connectLocalKey(acct: LocalAccount): ConnectedWallet {
-  return {
-    kind: 'localkey', label: 'In-browser test key', account: acct.account, publicKey: acct.publicKey,
-    async sign(cmd) { return signHash(cmdHash(cmd), acct.secretKey); },
-  };
-}
+// ---------------- (removed: browser-held key material) ----------------
+// LocalAccount / connectLocalKey were REMOVED (2026-08-01). This page no longer
+// generates, stores, imports or signs with private keys of its own: every
+// signature comes from a wallet the user already controls. Do not reintroduce
+// browser-held key material — a site that mints secrets for you teaches a habit
+// that does not survive a convincing clone of that site.
 
 // Sign our unsigned command with the connected wallet, then CRYPTOGRAPHICALLY VERIFY
 // that what came back really is a signature over OUR command hash by the account we


### PR DESCRIPTION
Continues #121, which merged after its first commit — these five landed on that branch afterwards and never reached `main`.

**What `main` has today:** the secret-key import field removed and the chain-0 balance copy. Coherent, but it still generates and stores a browser key, and still carries the hydration bug.

---

## 1. Claiming asks the user for nothing ⭐

A claim now needs no wallet prompt, no device, no KDA — **and no wallet at all.**

A sponsored transaction does need **a** signer: the node grants the station's `GAS_PAYER` capability by scanning the signers' capability lists, so with none the station's guard never opens. But it never had to be the *user's* wallet — that signature says exactly one thing: *"the station may pay this fee."*

| | user prompt | key stored | phishable |
|---|---|---|---|
| persisted browser key *(main today)* | no | **yes** — backup/restore/import | **yes** |
| connected wallet signs | **yes** | no | no |
| **ephemeral in-memory key** *(this PR)* | **no** | **no** | **no** |

Matches [`binance-otc-deal-locker`'s `virtual_signer.ts`](https://github.com/CryptoPascal31/binance-otc-deal-locker/blob/main/frontend/otc-lock/src/lib/virtual_signer.ts). Generated lazily (never during SSR), never stored, never exported or importable, never holds tokens, different every page load.

**No wallet needed to claim.** Claims carry no claimer signature by design, so the page only needs a destination — paste a `k:` address from a hardware wallet that never comes online, or a fresh account.

## 2. No browser-held key material

Removes the generated key, its `localStorage` slot, backup/restore, the wallet option, and `connectLocalKey`/`LocalAccount` — with the reason recorded where each was.

The **vote key** was built around the browser key as its hot signer. It now nominates *another account you control* by its **public** key. Same mechanism, nothing secret entered.

## 3. Hydration bug that could disable the Ecko button

**Pre-existing on `main`, live since launch.** `eckoAvailable()` reads `window` during render, so the server sends `disabled=""` and a client with the extension renders it enabled. React does **not** patch attribute mismatches — the server's `disabled` can stick, leaving the button unclickable for exactly the users who have Ecko.

Detection moved into an effect with a tri-state (`null` = detecting), which both the server and first client render produce, so hydration is clean. Re-checks for ~2s because the extension injects asynchronously.

## 4. Copy that had become false

The guide and landing page said the wallet *"never signs"* for a claim and *"even a Ledger claim needs no device interaction."* With the ephemeral signer that is **true again** — but it was false in between, and both now describe the actual mechanism rather than restating a promise.

## 5. A real lint error

`main` lints clean; this work introduced one **error**, so it could not have merged. `react-hooks/set-state-in-effect` was pointing at a genuine cascade: `refresh()` set `destAddr` while `destAddr` was in its own dependency list, recreating itself every run. Fixed at the root — functional update plus a ref for reads — rather than suppressed. Also cleared the dead code the removals stranded.

---

## Checks

`typecheck`, `lint`, `build` all pass.

## Tested on mainnet

Three real claims through this build — with a wallet connected, and with only a pasted address. All landed, none prompted, station float healthy (`0.00018 / 0.5 KDA` for three claims).