### PR TITLE
fix(token): show the destination balance and the claim transaction; Zelcore on macOS

### DIFF
--- a/src/app/token/guide/page.tsx
+++ b/src/app/token/guide/page.tsx
@@ -41,7 +41,7 @@ export default function TokenGuide() {
         </p>
         <ul>
                     <li><b>EckoWallet</b> — browser extension. Must be on the site&apos;s network (see below).</li>
-          <li><b>Zelcore</b> — desktop app. Log in first; the site talks to its local signing API.</li>
+          <li><b>Zelcore</b> — desktop app. Log in first; the site talks to its local signing API. <b>Not available in Safari:</b> Safari is the only browser that blocks a website from reaching a local app, so Zelcore cannot be connected there however it is configured — use Chrome, Brave or Edge for Zelcore, or claim with no wallet at all (see below).</li>
           <li><b>Ledger</b> — hardware, via WebHID (Chrome/Edge/Brave; Kadena app open). The page asks the device to <b>display</b> the transaction so you can check the recipient and amount on the device itself. Leave <b>blind signing off</b>: if the device shows only a hash it cannot tell you what you are approving, and this page will warn you before it continues.</li>
         </ul>
 
@@ -55,6 +55,8 @@ export default function TokenGuide() {
         <ul>
           <li>Pick the open claim round and answer its quest. Quests are published on the PCO channels together with the round id; the answer, normalized to lowercase, is the claim code.</li>
           <li>Claim. The gas station pays the fee; tokens land in your <b>active wallet&apos;s</b> account.</li>
+          <li><b>No wallet? You can still claim.</b> A claim carries no claimer signature — nothing of yours signs it — so you can paste any <span className={styles.mono}>k:</span> address into the receiving-address field and claim straight to it. This is the route for a hardware wallet kept in a safe, and for anyone whose browser cannot reach their wallet.</li>
+          <li><b>Where to see your PCO.</b> Most wallets list only KDA and well-known tokens, so yours may show nothing after a successful claim — a display limit, not a missing balance. The token page reads the balance from the chain itself, and every claim shows a transaction id you can check against any Kadena node or explorer.</li>
         </ul>
         <p>
           On-chain rules that keep this fair: <b>one claim per account per round</b>, a fixed budget

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -9,7 +9,7 @@ import {
   voteAs, setVoteKey, clearVoteKey, voteKeyActive, rotate, lookupAllChains, kdaBalance,
   type Round, type Proposal, checkCode } from '@/lib/pco';
 import {
-  connectEcko, connectZelcore, connectLedger, eckoAvailable,
+  connectEcko, connectZelcore, connectLedger, eckoAvailable, zelcoreBlockedByBrowser,
   type ConnectedWallet,
 } from '@/lib/wallets';
 
@@ -47,6 +47,22 @@ export default function TokenApp() {
   const [rotKey, setRotKey] = useState('');
   const [lookup, setLookup] = useState('');
   const [lookupResult, setLookupResult] = useState<{ label: string; total?: number; perChain?: { chain: string; balance: number }[] } | null>(null);
+  // THE DESTINATION'S OWN ON-CHAIN BALANCE, shown whether or not a wallet is
+  // connected. A claim needs no wallet, so a user can (correctly) claim to a
+  // pasted address while connected to nothing — and until now the page then
+  // showed them NOTHING afterwards: the balance panel renders only for a
+  // connected wallet, and no ordinary wallet lists a namespaced token like PCO.
+  // A successful claim was therefore indistinguishable from a failed one, which
+  // is exactly how one got reported as "the funds were not sent". null = no
+  // valid address to read yet.
+  const [destBal, setDestBal] = useState<number | null>(null);
+  const [destNonce, setDestNonce] = useState(0);   // bump to force a re-read (e.g. after claiming)
+  // A durable record of the last claim — deliberately NOT the transient status
+  // line, which the next message overwrites. This is the user's evidence.
+  const [receipt, setReceipt] = useState<{ reqKey: string; amount: number; account: string; round: string } | null>(null);
+  // Detected after mount, never during render: reading navigator on the server
+  // would render one thing and the client another (see the Ecko note above).
+  const [safariZelcore, setSafariZelcore] = useState(false);
 
   const say = (msg: string, kind: Status extends null ? never : 'info' | 'ok' | 'err' = 'info') => setStatus({ msg, kind });
 
@@ -131,6 +147,41 @@ export default function TokenApp() {
   // always reads the current value without listing it as a dependency.
   useEffect(() => { destAddrRef.current = destAddr; }, [destAddr]);
 
+  // Deferred, not called in the effect body: setting state synchronously there
+  // is a cascading render, which is the rule the first-refresh effect below
+  // already dodges the same way.
+  useEffect(() => {
+    const t = setTimeout(() => setSafariZelcore(zelcoreBlockedByBrowser()), 0);
+    return () => clearTimeout(t);
+  }, []);
+
+  // The destination balance gets its OWN effect rather than living in refresh().
+  // refresh() *writes* destAddr, so depending on destAddr there is the cascade
+  // that was removed earlier; this effect only READS destAddr and writes a
+  // different piece of state, so it cannot feed itself. Debounced so typing an
+  // address does not fire a request per keystroke.
+  useEffect(() => {
+    const a = destAddr.trim();
+    const sel = rounds.find((r) => r.id === roundId) ?? rounds[0];
+    let live = true;
+    // Everything, including clearing the figure for a half-typed address, happens
+    // inside the timer: no setState runs synchronously in the effect body.
+    const t = setTimeout(() => {
+      if (!live) return;
+      if (!/^k:[0-9a-f]{64}$/.test(a)) { setDestBal(null); return; }
+      // balance() already maps a not-yet-existing account to 0, so a fresh
+      // address reads as 0 rather than throwing.
+      balance(a).then((b) => { if (live) setDestBal(b); }).catch(() => { if (live) setDestBal(null); });
+      // Settle "has this DESTINATION already claimed this round?" here too.
+      // refresh() cannot answer it without a wallet — it has no identity to ask
+      // about — so it left the button enabled for an address that had already
+      // claimed. Clicking then spent gas-station float on a transaction that
+      // could only fail, which is the very waste the local answer-check avoids.
+      if (sel) alreadyClaimed(sel.id, a).then((c) => { if (live) setClaimed(c); }).catch(() => {});
+    }, 400);
+    return () => { live = false; clearTimeout(t); };
+  }, [destAddr, destNonce, roundId, rounds]);
+
   const selectedRound = () => rounds.find((r) => r.id === roundId) ?? rounds[0];
 
   const doClaim = async () => {
@@ -159,7 +210,17 @@ export default function TokenApp() {
       return say("That answer doesn't match this round — nothing was submitted, so try again freely.", 'err');
     }
     setBusy(true); say(`Claiming "${round.id}" to ${destLabel} (the gas station pays the fee — nothing to sign)…`);
-    try { await claim(round, dest, code.trim().toLowerCase()); say(`Claimed ${round.amount} PCO to ${dest.account.slice(0, 14)}…!`, 'ok'); setCode(''); }
+    try {
+      // Keep the RESULT. It carries the request key — the transaction's
+      // permanent on-chain identifier — and throwing it away left a user whose
+      // claim had genuinely succeeded with no way to demonstrate that.
+      const res = await claim(round, dest, code.trim().toLowerCase());
+      const reqKey = String((res as { reqKey?: unknown }).reqKey ?? '');
+      setReceipt({ reqKey, amount: round.amount, account: a, round: round.id });
+      say(`Claimed ${round.amount} PCO to ${a.slice(0, 14)}…!`, 'ok');
+      setCode('');
+      setDestNonce((n) => n + 1);   // re-read the destination so the new balance shows
+    }
     catch (e) { say(`Claim failed: ${(e as Error).message}`, 'err'); }
     setBusy(false); void refresh();
   };
@@ -297,6 +358,16 @@ export default function TokenApp() {
             Ledger{wallet?.kind === 'ledger' && ' ✓'}
           </button>
         </p>
+        {safariZelcore && (
+          <p className={styles.muted}>
+            <b>Using Safari?</b> Safari blocks this page from reaching Zelcore — it is the only browser
+            that stops an HTTPS page from calling a local app, so the connection fails even with Zelcore
+            open and logged in. Connect Zelcore in Chrome, Brave or Edge instead — or simply{' '}
+            <b>claim without a wallet</b>: claiming needs no signature, so paste your{' '}
+            <span className={styles.mono}>k:</span> address in the receiving-address field below.
+            (EckoWallet and Ledger are unaffected.)
+          </p>
+        )}
         {wallet && (
           <>
             <p>
@@ -365,6 +436,16 @@ export default function TokenApp() {
             <button className={styles.btn} onClick={() => { setDestEdited(false); setDestAddr(wallet.account); }}>use my active wallet instead</button>
           </p>
         )}
+        {/* The destination's OWN balance, read live from the chain, shown with or
+            without a connected wallet. This is the only place a claimer without a
+            wallet can see that their tokens exist. */}
+        {destBal !== null && (
+          <p>
+            <span className={styles.mono}>{destAddr.trim().slice(0, 14)}…</span> holds{' '}
+            <b>{destBal.toLocaleString()} PCO</b> on <b>chain {CFG.chain}</b>
+            <span className={styles.muted}> — read from the chain just now, not from your wallet.</span>
+          </p>
+        )}
         <p className={styles.muted}>{pool.toLocaleString()} PCO left in the pool</p>
         <p className={styles.muted}>Pick a round and answer its community quest (published on the PCO channels with its round id):</p>
         <p>
@@ -380,6 +461,34 @@ export default function TokenApp() {
             {round ? `claim ${round.amount} PCO` : 'claim'}
           </button>
         </p>
+        {/* CLAIM RECEIPT — durable, unlike the status line, which the next message
+            overwrites. A claimer with no connected wallet previously got a
+            momentary "Claimed…" and nothing else: no balance (that panel needs a
+            wallet) and no transaction. Since ordinary wallets do not list a
+            namespaced token like PCO, their wallet showed nothing either, so a
+            successful claim looked exactly like a failed one. */}
+        {receipt && (
+          <div className={styles.info}>
+            <h3>✓ Claimed {receipt.amount.toLocaleString()} PCO — round &quot;{receipt.round}&quot;</h3>
+            <p>
+              Sent to <span className={styles.mono}>{receipt.account}</span> on <b>chain {CFG.chain}</b>.
+              <button className={styles.btn} onClick={() => { navigator.clipboard?.writeText(receipt.account).then(() => say('Address copied.', 'ok')).catch(() => say(receipt.account)); }}>copy address</button>
+            </p>
+            {receipt.reqKey && (
+              <p>
+                Transaction: <span className={styles.mono}>{receipt.reqKey}</span>
+                <button className={styles.btn} onClick={() => { navigator.clipboard?.writeText(receipt.reqKey).then(() => say('Transaction id copied.', 'ok')).catch(() => say(receipt.reqKey)); }}>copy</button>
+              </p>
+            )}
+            <p className={styles.muted}>
+              This transaction is final on Kadena mainnet. Its id (the request key) is permanent — anyone
+              can check it against any Kadena node or explorer, and it is proof independent of this page.
+              If your wallet does not show the PCO, that is a wallet display limit: most wallets list only
+              KDA and well-known tokens, not a namespaced one like PCO. The balance above comes from the
+              chain itself.
+            </p>
+          </div>
+        )}
         {/* Live feedback. The round's code hash is public chain data and the check
             is local, so we can tell the user their answer is right BEFORE they
             click — and a wrong one never becomes a transaction, so trying again
@@ -393,7 +502,7 @@ export default function TokenApp() {
         )}
         {claimed && (
           <p className={styles.muted}>
-            {destEdited && destAddr.trim() !== wallet?.account ? `That address (${destAddr.trim().slice(0, 14)}…)` : `Your active wallet (${wallet?.account.slice(0, 14)}…)`} already
+            {destEdited && destAddr.trim() !== wallet?.account ? `That address (${destAddr.trim().slice(0, 14)}…)` : `Your active wallet (${wallet?.account.slice(0, 14)}…)`}{' '}already
             claimed round &quot;{round?.id}&quot; — one claim per account per round; it holds those tokens.
             {rounds.length > 1 && ' Other open rounds are still claimable.'}
             {' '}A different destination can still claim this round.

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -6,14 +6,13 @@
 //   ledger   — Ledger hardware via WebHID (hash signing, loaded on demand)
 //
 // The page keeps OUR command envelope as the single source of truth (chain.ts
-// buildExec); wallets only contribute signatures over OUR hash. DEVNET PREVIEW:
-// wallets must be pointed at the devnet network — adapters surface honest
-// errors when they are not.
+// buildExec); wallets only contribute signatures over OUR hash. PCO is on
+// Kadena MAINNET, a network every wallet ships built in — adapters surface
+// honest errors when a wallet is pointed somewhere else.
 import { CFG, cmdHash, verifyHashSig, bytesToHex, type Cap } from './chain';
 import { blake2b } from '@noble/hashes/blake2b';
 
 const NETWORK_ID = CFG.networkId;
-const API_BASE = CFG.host;
 
 export type WalletKind = 'ecko' | 'zelcore' | 'ledger';
 
@@ -59,8 +58,16 @@ function eckoRequest(p: EckoProvider, args: Parameters<EckoProvider['request']>[
     new Promise<typeof ECKO_SILENT>((r) => setTimeout(() => r(ECKO_SILENT), ms)),
   ]);
 }
-function eckoNetworkHelp(expected: string): string {
-  return `EckoWallet must be on the devnet network. In EckoWallet: Settings → Networks → add one with Name: PCO devnet, URL: ${API_BASE}, Network ID: ${expected} — save it, select it as active, then reconnect. (This is a DEVNET preview; use test accounts only.)`;
+// PCO is on Kadena MAINNET, which every Kadena wallet already ships as a
+// built-in network — so the remedy is "switch to Mainnet", never "add a custom
+// network". (This text survived the mainnet cutover still describing a devnet
+// preview and telling holders to use test accounts only, which contradicted the
+// rest of the site and implied the live token was a test.) `actual` is the
+// network Ecko reported, when we know it — naming it saves the user a hunt.
+function eckoNetworkHelp(actual?: string): string {
+  return `EckoWallet is on ${actual ? `"${actual}"` : 'the wrong network'} — PCO is on Kadena Mainnet `
+    + `(network id ${NETWORK_ID}). Switch EckoWallet to Mainnet with its network selector, then reconnect. `
+    + `No custom network is needed: Mainnet is built in.`;
 }
 
 export async function connectEcko(onSessionEnd?: (reason: string) => void): Promise<ConnectedWallet> {
@@ -68,14 +75,14 @@ export async function connectEcko(onSessionEnd?: (reason: string) => void): Prom
   if (!p) throw new Error('EckoWallet not detected — install it from eckowallet.com and reload');
   const net = await eckoRequest(p, { method: 'kda_getNetwork' }, 3000);
   const activeNet = net !== ECKO_SILENT && typeof (net as Record<string, unknown>)?.networkId === 'string' ? (net as Record<string, string>).networkId : undefined;
-  if (activeNet && activeNet !== NETWORK_ID) throw new Error(eckoNetworkHelp(NETWORK_ID));
+  if (activeNet && activeNet !== NETWORK_ID) throw new Error(eckoNetworkHelp(activeNet));
 
   const res = await eckoRequest(p, { method: 'kda_connect', networkId: NETWORK_ID }, 120000);
   if (res === ECKO_SILENT) throw new Error('No answer from EckoWallet — the request may have been dismissed; try again');
   const r = res as Record<string, unknown>;
   if (r.status !== 'success') {
     const msg = String(r.message ?? '');
-    if (/network invalid|invalid network/i.test(msg)) throw new Error(eckoNetworkHelp(NETWORK_ID));
+    if (/network invalid|invalid network/i.test(msg)) throw new Error(eckoNetworkHelp(activeNet));
     if (/connect fail|rejected/i.test(msg)) throw new Error('Connection declined in EckoWallet');
     throw new Error(`EckoWallet refused the connection${msg ? `: ${msg}` : ''}`);
   }
@@ -101,7 +108,7 @@ export async function connectEcko(onSessionEnd?: (reason: string) => void): Prom
       const s = st as Record<string, unknown>;
       if (st === ECKO_SILENT) throw new Error('No answer from EckoWallet — is it unlocked?');
       if (s.status !== 'success') {
-        if (/invalid network|network invalid/i.test(String(s.message ?? ''))) throw new Error(eckoNetworkHelp(NETWORK_ID));
+        if (/invalid network|network invalid/i.test(String(s.message ?? ''))) throw new Error(eckoNetworkHelp());
         throw new Error('EckoWallet session expired — reconnect and try again');
       }
       const r2 = await eckoRequest(p, { method: 'kda_requestQuickSign', data: { networkId: NETWORK_ID, commandSigDatas: [{ cmd, sigs: [{ pubKey: pub, sig: null }] }] } }, 180000);
@@ -127,19 +134,66 @@ export async function connectEcko(onSessionEnd?: (reason: string) => void): Prom
 // ---------------- Zelcore (localhost signing API) ----------------
 const ZELCORE = 'http://127.0.0.1:9467';
 const ZELCORE_HELP = 'Zelcore not reachable — open the Zelcore app and log in, then try again. If the browser asked about accessing devices on your local network, allow it and retry.';
+
+/**
+ * Safari is the ONE browser that blocks an HTTPS page from calling a local app
+ * over http://127.0.0.1 — it treats the loopback request as mixed content and
+ * fails it inside the browser, so it never reaches Zelcore however correctly
+ * Zelcore is running and logged in.
+ *
+ * Safari being the macOS default is why "Zelcore will not connect" arrives as a
+ * macOS report while the same build connects fine elsewhere. The generic advice
+ * ("open the app and log in") then sends exactly those users to re-check the one
+ * thing that was never wrong, so this case gets its own message — and, more
+ * usefully, points at the path that works for them TODAY: claiming needs no
+ * signature at all, so a Safari user can claim without connecting anything.
+ */
+export function zelcoreBlockedByBrowser(): boolean {
+  if (typeof navigator === 'undefined' || typeof location === 'undefined') return false;
+  const ua = navigator.userAgent;
+  const safari = /safari/i.test(ua) && !/chrome|chromium|crios|fxios|edg|android|opr/i.test(ua);
+  return safari && location.protocol === 'https:';
+}
+const ZELCORE_SAFARI =
+  'Safari will not let this page reach Zelcore. It is the only browser that blocks an HTTPS page from ' +
+  'calling a local app on 127.0.0.1, so the request never leaves Safari — even with Zelcore open and ' +
+  'logged in. Two ways forward: connect Zelcore in Chrome, Brave or Edge, or skip the wallet entirely — ' +
+  'claiming needs no signature, so paste your k: address into the receiving-address field below and ' +
+  'claim right here in Safari.';
 export async function connectZelcore(): Promise<ConnectedWallet> {
-  let accounts: string[];
+  // Three failures that need three different answers, so they are caught
+  // separately. Wrapping them all in one catch (as this did) flattened an
+  // erroring or wrong server into "Zelcore is not running" — a claim the code
+  // never established, and the least useful thing to tell someone whose Zelcore
+  // IS running.
+  let res: Response;
   try {
     // a dead local endpoint can HANG instead of refusing (browser local-network
     // gating) — bound the probe so the UI never sits on "Connecting…" forever
     const ctl = new AbortController();
     const timer = setTimeout(() => ctl.abort(), 5000);
-    const res = await fetch(`${ZELCORE}/v1/accounts`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ asset: 'kadena' }), signal: ctl.signal });
+    res = await fetch(`${ZELCORE}/v1/accounts`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ asset: 'kadena' }), signal: ctl.signal });
     clearTimeout(timer);
+  } catch {
+    // The request never completed: app closed, or the browser refused to send it
+    // at all (Safari's mixed-content block on 127.0.0.1). No status exists here.
+    throw new Error(zelcoreBlockedByBrowser() ? ZELCORE_SAFARI : ZELCORE_HELP);
+  }
+  // 9467 is the SHARED Kadena signing-API port — other Kadena wallets bind it
+  // too, so "something answered" is not "Zelcore answered". Surface the status
+  // rather than guessing; the sibling signing call below has always done this.
+  if (!res.ok) {
+    throw new Error(
+      `The local Kadena signing API answered ${res.status} at ${ZELCORE}. Zelcore may be locked, or ` +
+      `another Kadena wallet may be holding port 9467 — close the other wallet, unlock Zelcore, and retry.`,
+    );
+  }
+  let accounts: string[];
+  try {
     const j = await res.json();
     accounts = (j?.data ?? []).filter((a: string) => typeof a === 'string' && a.startsWith('k:'));
   } catch {
-    throw new Error(ZELCORE_HELP);
+    throw new Error(`The app on ${ZELCORE} replied, but not with the account list Zelcore returns — check that it is Zelcore listening on port 9467 and not another wallet.`);
   }
   if (accounts.length === 0) throw new Error('Zelcore returned no k: Kadena accounts');
   const account = accounts[0];


### PR DESCRIPTION
Fixes the three items reported against the live token page.

## What was actually wrong

The report was "Zelcore did not connect", "the funds were not sent when a k: address was added manually", and "can we show the tx so users can validate". On chain, **the claim had succeeded** — `k:493f13f2…` holds 100 PCO, and the genesis round shows 4 claims against a pool of 899,600. Nothing was lost. All three items are one causal chain:

1. Zelcore cannot connect in Safari (macOS default browser) — Safari is the only browser that blocks an HTTPS page from reaching a local app on `127.0.0.1`, so the request never leaves the browser.
2. With no wallet connected, the user pasted a destination and claimed. That works — a claim carries no claimer signature.
3. The claim succeeded, but the page showed **no evidence at all**: the balance panel renders only for a connected wallet, and no ordinary wallet lists a namespaced token like PCO. A success was indistinguishable from a failure.

So item 3 (show the transaction) is the real fix for item 2.

## Changes

**Evidence**
- The destination account's on-chain PCO balance is read and displayed whether or not a wallet is connected.
- The claim result is kept and rendered as a durable receipt — amount, destination, and request key — rather than a status line that the next message overwrites.
- The receipt explains that a wallet showing nothing is a display limit, not a missing balance.

**Correctness**
- The claim button is now disabled when the *pasted* destination has already claimed the round. This was only computed for a connected wallet, so a no-wallet user could submit a transaction that could only fail, spending gas-station float — the waste the local answer-check exists to prevent.

**Zelcore**
- Safari is detected and explained, both up front on the page and in the connect error, pointing at the no-wallet claim path that works in Safari today.
- `res.ok` is checked on the accounts probe. Port 9467 is the shared Kadena signing-API port, so an error response was being reported as "Zelcore not reachable" or "no k: accounts" — neither of which the code had established.

**Leftover from the mainnet cutover**
- The EckoWallet network-mismatch message still told holders to add a network named "PCO devnet" and to "use test accounts only", on a mainnet build. It now says to switch to Mainnet, and names the network Ecko actually reported.

## Verification

- `npm run lint` clean, `npm run build` clean.
- Exercised against **mainnet** in a browser with no wallet connected, using the reported address: the page shows `k:493f13f278fe… holds 100 PCO on chain 0`, reports `already claimed round "genesis"`, and keeps the claim button disabled.