### PR TITLE
fix(mobile): no page may be wider than the phone it is viewed on

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -57,3 +57,16 @@ jobs:
       - name: Build
         # The step that actually catches a breaking dependency bump.
         run: npm run build
+
+      - name: Mobile layout (no page may be wider than the phone it is viewed on)
+        # NEITHER lint NOR build can see layout, so a navbar that laid its links
+        # out in one non-wrapping row shipped to production and made every page
+        # unreadable on a phone: the body measured 907px on a 375px screen, and
+        # because `overflow-x: hidden` CLIPS rather than scrolls, the only way to
+        # read the site was to rotate the device. It took a user report to find.
+        # This measures the built export at 320/375/414px and fails on overflow.
+        run: |
+          npx playwright install --with-deps chromium
+          npx --yes serve out -l 3000 --no-clipboard > /dev/null 2>&1 &
+          curl -s --retry 40 --retry-delay 1 --retry-connrefused -m 90 -o /dev/null http://localhost:3000/
+          npm run mobile-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
+        "playwright": "^1.61.1",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1348,13 +1349,6 @@
         "tailwindcss": "4.3.3"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
-      "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
@@ -1472,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1492,9 +1483,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1512,9 +1500,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1532,9 +1517,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,13 +1669,6 @@
         "postcss": "^8.5.16",
         "tailwindcss": "4.3.3"
       }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
-      "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -3919,6 +3894,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5040,9 +5030,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5064,9 +5051,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5088,9 +5072,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5112,9 +5093,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5679,6 +5657,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "mobile-check": "node scripts/mobile-check.mjs"
   },
   "dependencies": {
     "@ledgerhq/hw-transport-webhid": "^6.36.0",
@@ -26,6 +27,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
+    "playwright": "^1.61.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/scripts/mobile-check.mjs
+++ b/scripts/mobile-check.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// mobile-check.mjs — fails if any page is wider than the phone it is viewed on.
+//
+// WHY THIS EXISTS. The navbar laid its links out as one non-wrapping flex row,
+// so on a 375px screen the body measured 907px. No horizontal scroll was
+// offered, so the site simply looked cut off and the only way to read it was to
+// rotate the phone. It shipped that way, on every page, because nothing ever
+// measured a page at a phone width — `next build` and `eslint` cannot see
+// layout, and the repo has no test suite.
+//
+// The check is one assertion: document width must not exceed the viewport.
+// When it fails it names the SHALLOWEST offending elements, because the widest
+// element is usually a symptom and its container is the cause.
+//
+// Usage:  node scripts/mobile-check.mjs [baseURL]      (default http://localhost:3000)
+// Exit 0 = every route fits at every width. Exit 1 = at least one overflows.
+import { chromium } from 'playwright';
+
+const BASE = process.argv[2] || 'http://localhost:3000';
+const ROUTES = [
+  '/', '/token', '/token/guide', '/community', '/contracts', '/docs',
+  '/mission-vision', '/nft', '/nft/buyers', '/nft/creators', '/nft/sellers',
+  '/nft/marketplaces', '/roadmap',
+];
+// 320 = smallest phone still in use (iPhone SE 1st gen); 375 = the common case;
+// 414 = large phones. A layout that holds at 320 holds everywhere.
+const WIDTHS = [320, 375, 414];
+
+const measure = () => {
+  const vw = document.documentElement.clientWidth;
+  const seen = new Set();
+  const offenders = [];
+  document.querySelectorAll('*').forEach((el) => {
+    const b = el.getBoundingClientRect();
+    if (b.width === 0 && b.height === 0) return;
+    if (b.right > vw + 1 || b.width > vw + 1) {
+      // Report only the shallowest offender in any subtree: a wide child inside
+      // an already-wide parent is noise, the parent is the bug.
+      let p = el.parentElement;
+      while (p) { if (seen.has(p)) return; p = p.parentElement; }
+      seen.add(el);
+      offenders.push({
+        tag: el.tagName.toLowerCase(),
+        cls: (el.className || '').toString().trim().slice(0, 44),
+        w: Math.round(b.width),
+        right: Math.round(b.right),
+        text: (el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 44),
+      });
+    }
+  });
+  return { vw, docWidth: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth), offenders };
+};
+
+// Use whatever chromium is already on this machine. PLAYWRIGHT_CHROMIUM lets a
+// cached build be reused rather than downloading one; without it, Playwright's
+// bundled default is used, which is what CI would do.
+const exe = process.env.PLAYWRIGHT_CHROMIUM;
+const browser = await chromium.launch(exe ? { executablePath: exe } : {});
+let failures = 0, checked = 0;
+
+for (const width of WIDTHS) {
+  const ctx = await browser.newContext({ viewport: { width, height: 780 }, deviceScaleFactor: 2 });
+  const page = await ctx.newPage();
+  for (const route of ROUTES) {
+    // NOT 'networkidle': the Next dev server holds an HMR websocket open, so
+    // network is never idle and this hangs forever. 'load' is what we need
+    // anyway — layout is settled once stylesheets have applied.
+    const res = await page.goto(BASE + route, { waitUntil: 'load', timeout: 20000 }).catch(() => null);
+    if (!res || !res.ok()) { console.log(`  SKIP  ${width}px ${route} (HTTP ${res ? res.status() : 'no response'})`); continue; }
+    checked++;
+    const { vw, docWidth, offenders } = await page.evaluate(measure);
+    if (docWidth > vw + 1) {
+      failures++;
+      console.log(`  FAIL  ${width}px ${route} — document ${docWidth}px in a ${vw}px viewport`);
+      for (const o of offenders.slice(0, 4)) {
+        console.log(`          <${o.tag} class="${o.cls}"> ${o.w}px wide, right edge ${o.right}px  "${o.text}"`);
+      }
+    }
+  }
+  await ctx.close();
+}
+await browser.close();
+
+console.log(`\n-- mobile-check: ${checked} page-widths measured at ${WIDTHS.join('/')}px --`);
+if (!checked) { console.log('RESULT: FAIL (nothing was measured — is the dev server running?)'); process.exit(1); }
+if (failures) { console.log(`RESULT: FAIL (${failures} overflow${failures > 1 ? 's' : ''})`); process.exit(1); }
+console.log('RESULT: PASS (every route fits its viewport)');

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,8 +28,33 @@
 html,
 body {
   max-width: 100vw;
+  /* NOTE, because this line is a trap as much as a guard: it does not FIX
+     overflow, it CLIPS it. Anything wider than the viewport becomes unreachable
+     rather than scrollable — which is exactly how a 907px navbar on a 375px
+     phone read as "the page is cut off and I have to rotate to see anything".
+     Keep it (a correct layout should never scroll sideways), but never treat a
+     page as fine because this hid the evidence. `npm run mobile-check` measures
+     scrollWidth, so it sees through this. */
   overflow-x: hidden;
   font-family: var(--font-sans);
+}
+
+/* Form controls do not shrink below their intrinsic size on their own, so a
+   <select> holding a long option label pushed the token page past a 320px
+   viewport. Nothing here should ever be wider than what contains it. */
+input,
+select,
+textarea,
+button {
+  max-width: 100%;
+}
+
+/* Account ids, module hashes and request keys are 43-66 unbreakable characters.
+   Without this they set a minimum width no phone can satisfy. */
+.mono,
+code,
+pre {
+  overflow-wrap: anywhere;
 }
 
 body {

--- a/src/styles/community-cta.module.css
+++ b/src/styles/community-cta.module.css
@@ -12,7 +12,7 @@
 }
 
 .communityCTA h2 {
-  font-size: 2.5rem;
+  font-size: clamp(1.50rem, 5.5vw, 2.5rem);
   font-weight: 700;
   margin-bottom: 1.5rem;
 }

--- a/src/styles/community.module.css
+++ b/src/styles/community.module.css
@@ -10,7 +10,7 @@
 }
 
 .community h1 {
-  font-size: 3rem;
+  font-size: clamp(1.80rem, 6.6vw, 3rem);
   margin-bottom: 1rem;
 }
 
@@ -22,7 +22,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
   gap: 2rem;
 }
 

--- a/src/styles/contract-preview.module.css
+++ b/src/styles/contract-preview.module.css
@@ -9,7 +9,7 @@
 }
 
 .contractPreview h2 {
-  font-size: 2.5rem;
+  font-size: clamp(1.50rem, 5.5vw, 2.5rem);
   font-weight: 700;
   margin-bottom: 1rem;
 }
@@ -22,7 +22,7 @@
 
 .cardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
   gap: 2rem;
   text-align: left;
 }

--- a/src/styles/contracts.module.css
+++ b/src/styles/contracts.module.css
@@ -9,13 +9,13 @@
 }
 
 .catalog h1 {
-  font-size: 3rem;
+  font-size: clamp(1.80rem, 6.6vw, 3rem);
   margin-bottom: 2rem;
 }
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
   gap: 2rem;
 }
 

--- a/src/styles/docs.module.css
+++ b/src/styles/docs.module.css
@@ -10,7 +10,7 @@
 }
 
 .hub h1 {
-  font-size: 3rem;
+  font-size: clamp(1.80rem, 6.6vw, 3rem);
   margin-bottom: 1rem;
 }
 
@@ -22,7 +22,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
   gap: 2rem;
 }
 

--- a/src/styles/hero.module.css
+++ b/src/styles/hero.module.css
@@ -17,7 +17,7 @@
 }
 
 .hero h1 {
-  font-size: 3.5rem;
+  font-size: clamp(2.10rem, 7.7vw, 3.5rem);
   font-weight: 700;
   margin-bottom: 1.5rem;
   line-height: 1.2;

--- a/src/styles/home-docs-hub.module.css
+++ b/src/styles/home-docs-hub.module.css
@@ -9,14 +9,14 @@
 }
 
 .docsHub h2 {
-  font-size: 2.5rem;
+  font-size: clamp(1.50rem, 5.5vw, 2.5rem);
   font-weight: 700;
   margin-bottom: 3rem;
 }
 
 .linksGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(250px, 100%), 1fr));
   gap: 2rem;
 }
 

--- a/src/styles/mission-vision.module.css
+++ b/src/styles/mission-vision.module.css
@@ -9,7 +9,7 @@
 }
 
 .content h1 {
-  font-size: 3rem;
+  font-size: clamp(1.80rem, 6.6vw, 3rem);
   margin-bottom: 2rem;
 }
 

--- a/src/styles/navbar.module.css
+++ b/src/styles/navbar.module.css
@@ -1,5 +1,14 @@
+/* The navbar is on every page, so its layout decides whether the whole SITE is
+   usable on a phone. It previously laid the links out as a single non-wrapping
+   flex row: on a 375px screen that produced a 907px-wide body — 2.4x the
+   viewport — with no horizontal scroll offered, so the page simply appeared
+   cut off and rotating to landscape was the only way to read it.
+   Wrapping (not a hamburger) is the fix: no JavaScript, nothing to open, and
+   every link stays reachable at any width. */
 .navbar {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
   justify-content: space-between;
   align-items: center;
   padding: 1.5rem 4rem;
@@ -16,11 +25,13 @@
 
 .navLinks {
   display: flex;
+  flex-wrap: wrap;
+  /* `gap` rather than per-item margin: margins do not space WRAPPED rows, so a
+     second row would collide with the first. Row gap first, column gap second. */
+  gap: 0.5rem 2.5rem;
   list-style: none;
-}
-
-.navLinks li {
-  margin-left: 2.5rem;
+  margin: 0;
+  padding: 0;
 }
 
 .navLinks a {
@@ -33,4 +44,18 @@
 
 .navLinks a:hover {
   color: var(--text-link-hover);
+}
+
+/* Phones and small tablets. 4rem of side padding is 128px of a 375px screen —
+   a third of it — before any content is drawn. */
+@media (max-width: 720px) {
+  .navbar {
+    padding: 1rem 1.25rem;
+    justify-content: center;
+  }
+  .navLinks {
+    gap: 0.5rem 1.25rem;
+    justify-content: center;
+    width: 100%;
+  }
 }

--- a/src/styles/nft.module.css
+++ b/src/styles/nft.module.css
@@ -9,7 +9,7 @@
 }
 
 .page h1 {
-  font-size: 2.6rem;
+  font-size: clamp(1.56rem, 5.7vw, 2.6rem);
   margin-bottom: 0.75rem;
 }
 
@@ -189,7 +189,7 @@
 
 .splitOut {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
   gap: 0.75rem;
 }
 
@@ -224,7 +224,7 @@
 
 .cardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr));
   gap: 1.25rem;
   margin: 1.5rem 0;
 }

--- a/src/styles/roadmap.module.css
+++ b/src/styles/roadmap.module.css
@@ -9,7 +9,7 @@
 }
 
 .roadmap h1 {
-  font-size: 3rem;
+  font-size: clamp(1.80rem, 6.6vw, 3rem);
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
**Reported:** on a phone the site cannot be scrolled sideways and has to be turned landscape to read anything.

## Cause

Measured at 375px: the navbar laid its links out as a **single non-wrapping flex row**, so the body measured **907px — 2.4× the viewport**. The navbar is on every page, so this broke the whole site, not one route.

It presented as *"cannot scroll"* rather than *"scrolls awkwardly"* because `globals.css` sets `overflow-x: hidden` on html/body. **That does not fix overflow, it clips it** — the extra 532px became unreachable instead of scrollable, and rotating was the only way to see it. Kept (a correct layout should never scroll sideways) but now documented as the trap it is.

## Seven more overflows were hiding behind it

Sweeping every route at 320/375/414px:

| defect | why it overflows | fix |
|---|---|---|
| `minmax(300px, 1fr)` card grids | hard 300px floor; at 320px with 2rem padding only 256px is available | `minmax(min(300px, 100%), 1fr)` |
| headings fixed at 2.5–3.5rem | "Documentation" alone is ~360px wide in a 247px box — `/docs` overflowed at **every** width, 414 included | fluid `clamp()`, desktop max unchanged |
| `<select>` | form controls do not shrink below intrinsic size | `max-width: 100%` |
| account ids / hashes | 43–66 unbreakable characters set an unsatisfiable minimum | `overflow-wrap: anywhere` |

**Result: 8 overflows → 0**, across 39 page-widths.

## Desktop is unchanged — verified, not assumed

`h1` still computes to exactly **48px** (the original 3rem), nav links still sit on **one row**, the docs grid is still **3 × 357px**, no overflow.

## New gate: `npm run mobile-check`

Neither `lint` nor `build` can see layout, and this repo has no test suite — so **nothing could have caught this**. It took a user report. The check measures the built export at three phone widths and fails on overflow, naming the shallowest offending element (the widest element is usually a symptom; its container is the cause).

**Proven able to fail, not just to pass.** With `h1{width:900px}` injected into the built CSS it reports 916–964px documents on every route; removed, it passes again.

⚠️ **Note for anyone extending it:** injecting a DOM node into the served HTML is *not* a valid regression test here — React hydration removes it and the check then passes for the wrong reason. Inject CSS instead. My first attempt at this falsification was invalid for exactly that reason.

## Verification

`npm run lint` clean · `npm run build` clean · `mobile-check` PASS (39 page-widths) · desktop layout measured unchanged.