### PR TITLE
fix(token): show what is left in the selected round, not just the pool

### DIFF
--- a/scripts/mobile-check.mjs
+++ b/scripts/mobile-check.mjs
@@ -17,11 +17,14 @@
 import { chromium } from 'playwright';
 
 const BASE = process.argv[2] || 'http://localhost:3000';
-const ROUTES = [
-  '/', '/token', '/token/guide', '/community', '/contracts', '/docs',
-  '/mission-vision', '/nft', '/nft/buyers', '/nft/creators', '/nft/sellers',
-  '/nft/marketplaces', '/roadmap',
-];
+// Override for another site: MOBILE_CHECK_ROUTES="/,/about,/pricing"
+const ROUTES = process.env.MOBILE_CHECK_ROUTES
+  ? process.env.MOBILE_CHECK_ROUTES.split(',').map((s) => s.trim()).filter(Boolean)
+  : [
+      '/', '/token', '/token/guide', '/community', '/contracts', '/docs',
+      '/mission-vision', '/nft', '/nft/buyers', '/nft/creators', '/nft/sellers',
+      '/nft/marketplaces', '/roadmap',
+    ];
 // 320 = smallest phone still in use (iPhone SE 1st gen); 375 = the common case;
 // 414 = large phones. A layout that holds at 320 holds everywhere.
 const WIDTHS = [320, 375, 414];

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -446,12 +446,39 @@ export default function TokenApp() {
             <span className={styles.muted}> — read from the chain just now, not from your wallet.</span>
           </p>
         )}
-        <p className={styles.muted}>{pool.toLocaleString()} PCO left in the pool</p>
         <p className={styles.muted}>Pick a round and answer its community quest (published on the PCO channels with its round id):</p>
         <p>
           <select value={roundId} onChange={(e) => setRoundId(e.target.value)}>
-            {rounds.map((r) => <option key={r.id} value={r.id}>{r.id} — {r.amount} PCO (until {r.closes.slice(0, 10)})</option>)}
+            {/* Each option carries its OWN remaining budget: with several rounds open,
+                which ones still have room is the thing being chosen between. */}
+            {rounds.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.id} — {r.amount} PCO · {Math.max(0, r.budget - r.claimed).toLocaleString()} left (until {r.closes.slice(0, 10)})
+              </option>
+            ))}
           </select>
+        </p>
+        {/* WHAT BOUNDS A CLAIMER IS THE ROUND'S BUDGET, NOT THE POOL. This used to show
+            only the pool — 898,200 PCO beside a 100 PCO claim — which reads as "that is
+            what this quest pays out" when the round's own budget is 30,000, a 30x
+            overstatement. The pool stays, demoted to what it actually is: the reserve
+            behind every round, present and future. */}
+        {round && (
+          <p>
+            <b>{Math.max(0, round.budget - round.claimed).toLocaleString()} PCO</b> left in this round
+            <span className={styles.muted}>
+              {' '}of {round.budget.toLocaleString()} — room for about{' '}
+              {Math.floor(Math.max(0, round.budget - round.claimed) / round.amount).toLocaleString()} more
+              claim{Math.floor(Math.max(0, round.budget - round.claimed) / round.amount) === 1 ? '' : 's'} at {round.amount}{' '}
+              {/* {' '} is required, not decoration: a text node that spans a newline has its
+                  leading whitespace stripped, so `{round.amount} PCO` compiled to "100PCO". */}
+              PCO each. When a round&apos;s budget runs out or its window closes, that round is over.
+            </span>
+          </p>
+        )}
+        <p className={styles.muted}>
+          The community pool behind all rounds holds {pool.toLocaleString()} PCO — that is the
+          reserve every round is funded from, not an amount claimable here.
         </p>
         <p>
           <input placeholder="answer" value={code} onChange={(e) => setCode(e.target.value)} />


### PR DESCRIPTION
**Reported:** selecting a quest shows the total pool, which reads as though the whole pool is claimable in that quest.

It is worse than misleading — it was a **32× overstatement**. Live mainnet, right now:

```
genesis round   budget 30,000 · claimed 1,800 · award 100  ->  28,200 left
page showed     898,200 PCO "left in the pool"
```

898,200 sat directly above a **claim 100 PCO** button. What actually bounds a claimer is the **round's budget**, never the pool.

## Changes

- The selected round shows **its own** remaining budget, what it started with, and roughly how many more claims that is at this round's award.
- **Each dropdown option carries its own remaining** — with several rounds open, which ones still have room is precisely what is being chosen between.
- The pool stays, demoted to what it really is: the reserve every round is funded from, stated explicitly as *not* claimable here.

Rendered against live chain data:

> genesis — 100 PCO · 28,200 left (until 2026-08-31)
>
> **28,200 PCO** left in this round of 30,000 — room for about 282 more claims at 100 PCO each. When a round's budget runs out or its window closes, that round is over.
>
> The community pool behind all rounds holds 898,200 PCO — that is the reserve every round is funded from, not an amount claimable here.

**No new chain reads.** `budget` and `claimed` were already parsed into `Round` and simply never displayed.

## A whitespace bug caught on the way

`{round.amount} PCO` compiled to **"100PCO"**. A JSX text node that spans a newline loses its leading space — the same rule produced `"…)already claimed"` in this panel earlier. Fixed with an explicit `{' '}`.

Worth flagging: **lint, typecheck and build all pass either way.** Only the rendered string shows it, which is why it reads as a typo and ships. Verified by inspecting the compiled chunk (`e$.amount,"PCO each.` → `e$.amount," `) and then `textContent` in the browser.

## Verification

Live-data render checked in-browser · arithmetic confirmed against chain (28,200 = 30,000 − 1,800; 282 = ⌊28,200/100⌋) · `lint` clean · `build` clean · `mobile-check` PASS at 320/375/414.