### PR TITLE
fix(a11y): close every WCAG 2.1 A/AA violation, and gate it

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -70,3 +70,10 @@ jobs:
           npx --yes serve out -l 3000 --no-clipboard > /dev/null 2>&1 &
           curl -s --retry 40 --retry-delay 1 --retry-connrefused -m 90 -o /dev/null http://localhost:3000/
           npm run mobile-check
+
+      - name: Accessibility (WCAG 2.1 A/AA)
+        # The claim flow's round <select> shipped with no accessible name — a
+        # screen reader announced the site's primary control as "combo box".
+        # Nothing here could catch that: lint and build do not read the a11y
+        # tree. Reuses the server started above.
+        run: npm run a11y-check

--- a/docs/accessibility-checklist.md
+++ b/docs/accessibility-checklist.md
@@ -1,0 +1,81 @@
+# Accessibility checklist
+
+**Standard: WCAG 2.1 Level A and AA.** Enforced mechanically on every pull request by
+`npm run a11y-check`, which runs axe-core over all 13 routes. A green run means those rules
+found nothing — not that the site is fully accessible; see *What this does not cover*.
+
+Last measured: 2026-08-02 — **0 violations across 13 routes**.
+
+## What is enforced automatically
+
+`scripts/a11y-check.mjs` fails the build on any WCAG 2.1 A/AA violation. It reports
+best-practice findings separately and does **not** fail on them: they are advice, and mixing
+them in makes a real failure easy to miss.
+
+Run it locally against a built export:
+
+```bash
+npm run build
+npx serve out -l 3000 &
+npm run a11y-check
+```
+
+Point it at any origin (`npm run a11y-check -- https://pact-community.org`), and override the
+route list with `MOBILE_CHECK_ROUTES` (shared with `mobile-check`).
+
+## Violations found and fixed on the first run
+
+These are recorded because they are the failure modes this site actually produced — a
+checklist derived from the standard rather than from the site would have listed neither.
+
+| Rule | Impact | What it was |
+|---|---|---|
+| `select-name` | **critical** | The claim-round `<select>` had no accessible name. Its visible label sat in a separate paragraph, so a screen reader announced only "combo box" — on the primary action of the whole site. Fixed with `aria-label`. |
+| `color-contrast` | serious | A link hardcoded to `#0070f3` gave 4.22:1 on the dark background (AA needs 4.5:1), and the token banner's badge was white-on-pink at 2.81:1. |
+| `link-in-text-block` | serious | 27 links identified by colour alone. Colour is not a sufficient signal (1.4.1). |
+
+## Rules that apply when writing this site
+
+1. **Every control needs an accessible name.** A visible label in a nearby element is not one.
+   Use `<label for>`, `aria-label`, or `aria-labelledby`. This is the rule that broke the claim
+   flow for screen-reader users.
+2. **Text contrast: 4.5:1 normal, 3:1 large** (≥24px, or ≥18.66px bold). Check against the
+   colour actually painted behind the element, not the page background.
+3. **Never introduce a raw hex.** Every colour comes from the tokens in `globals.css`. The one
+   contrast failure on this site was the one hardcoded hex in the stylesheet — the accessible
+   fix and the correct fix were the same change.
+4. **A link inside prose is underlined.** Colour alone does not identify it. Navigation, cards
+   and buttons are exempt: they are identifiable by position and shape.
+5. **Headings descend in order**, one `<h1>` per page. Do not pick a level for its size — use
+   the token scale.
+6. **Every image needs `alt`**; decorative images take `alt=""`, never a missing attribute.
+7. **Keyboard reachable, and visibly focused.** Anything clickable must be tabbable and show a
+   focus ring. Never remove an outline without replacing it.
+8. **Do not encode meaning in colour alone** — status, validity, required fields all need a
+   second signal (text, icon, underline).
+9. **Respect `prefers-reduced-motion`** for any animation.
+
+## What this does not cover
+
+Stated so a green run is never read as more than it is. axe detects roughly a third to a half
+of WCAG issues; the rest need a human:
+
+- **Screen-reader flow** — that the announced order and wording make sense, not merely that a
+  name exists.
+- **Keyboard journeys** — completing a claim, a vote, or a transfer without a mouse.
+- **Contrast over gradients and images**, which axe cannot compute reliably. The token banner
+  uses a gradient; its badge was checked by hand.
+- **Content quality** — link text that reads as "click here", or an `alt` that describes
+  nothing.
+- **Zoom to 200%** and 320px reflow. Reflow *is* covered mechanically, by `mobile-check`.
+- **Cognitive load** of the wallet and claim flows.
+
+## Compliance notes specific to PCO
+
+- The claim flow is the one journey that must never regress: it is the site's purpose, and it
+  is used by people who have never held a token before. Its `<select>` and inputs carry
+  explicit names for that reason.
+- Account ids and transaction hashes are 43–66 unbreakable characters. They wrap
+  (`overflow-wrap: anywhere`) so they neither overflow nor force a horizontal scroll.
+- The valueless-token disclosure must be readable, not merely present: it is body text, never
+  a low-contrast footnote.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "axe-core": "^4.12.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
         "playwright": "^1.61.1",
@@ -2652,9 +2653,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "mobile-check": "node scripts/mobile-check.mjs"
+    "mobile-check": "node scripts/mobile-check.mjs",
+    "a11y-check": "node scripts/a11y-check.mjs"
   },
   "dependencies": {
     "@ledgerhq/hw-transport-webhid": "^6.36.0",
@@ -25,6 +26,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "axe-core": "^4.12.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
     "playwright": "^1.61.1",

--- a/scripts/a11y-check.mjs
+++ b/scripts/a11y-check.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// a11y-check.mjs — run axe-core over every route and report WCAG violations.
+//
+// WHY THIS EXISTS. Issue #10 asked for an accessibility checklist. A checklist
+// written from a standard rather than from the site is a document that asserts
+// compliance nobody measured — the same defect as a gate that reports PASS
+// having examined nothing. So this measures first; the checklist records what
+// was actually found and what is actually enforced.
+//
+// Usage:  node scripts/a11y-check.mjs [baseURL]
+//   MOBILE_CHECK_ROUTES overrides the route list (shared with mobile-check).
+// Exit 0 = no violations at the configured level. Exit 1 = at least one.
+import { chromium } from 'playwright';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const axePath = require.resolve('axe-core/axe.min.js');
+const axeSource = require('node:fs').readFileSync(axePath, 'utf8');
+
+const BASE = process.argv[2] || 'http://localhost:3000';
+const ROUTES = process.env.MOBILE_CHECK_ROUTES
+  ? process.env.MOBILE_CHECK_ROUTES.split(',').map((s) => s.trim()).filter(Boolean)
+  : ['/', '/token', '/token/guide', '/community', '/contracts', '/docs',
+     '/mission-vision', '/nft', '/nft/buyers', '/nft/creators', '/nft/sellers',
+     '/nft/marketplaces', '/roadmap'];
+
+// WCAG 2.1 A + AA. Best-practice rules are reported separately: they are advice,
+// not the standard, and mixing them in makes a real failure easy to miss.
+const STANDARD = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+const exe = process.env.PLAYWRIGHT_CHROMIUM;
+const browser = await chromium.launch(exe ? { executablePath: exe } : {});
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+const page = await ctx.newPage();
+
+const failures = new Map();   // ruleId -> {impact, help, nodes:[{route,target}]}
+let advisory = 0, checked = 0;
+
+for (const route of ROUTES) {
+  const res = await page.goto(BASE + route, { waitUntil: 'load', timeout: 20000 }).catch(() => null);
+  if (!res || !res.ok()) { console.log(`  SKIP  ${route} (HTTP ${res ? res.status() : 'no response'})`); continue; }
+  await page.addScriptTag({ content: axeSource });
+  const r = await page.evaluate(async () => await window.axe.run(document, { resultTypes: ['violations'] }));
+  checked++;
+  for (const v of r.violations) {
+    const isStandard = v.tags.some((t) => ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'].includes(t));
+    if (!isStandard) { advisory++; continue; }
+    if (!failures.has(v.id)) failures.set(v.id, { impact: v.impact, help: v.help, nodes: [] });
+    for (const n of v.nodes) failures.get(v.id).nodes.push({ route, target: n.target.join(' ') });
+  }
+}
+await browser.close();
+
+console.log(`\n-- a11y-check: ${checked} route(s) against WCAG 2.1 A/AA (${STANDARD.join('/')}) --`);
+if (!checked) { console.log('RESULT: FAIL (nothing was measured — is the server running?)'); process.exit(1); }
+for (const [id, v] of [...failures].sort((a, b) => b[1].nodes.length - a[1].nodes.length)) {
+  console.log(`  ${String(v.impact).toUpperCase().padEnd(8)} ${id} — ${v.help} (${v.nodes.length} node(s))`);
+  for (const n of v.nodes.slice(0, 3)) console.log(`             ${n.route}  ${n.target.slice(0, 76)}`);
+  if (v.nodes.length > 3) console.log(`             …and ${v.nodes.length - 3} more`);
+}
+if (advisory) console.log(`  (${advisory} best-practice finding(s) not counted — advice, not the standard)`);
+if (failures.size) { console.log(`\nRESULT: FAIL (${failures.size} WCAG rule(s) violated)`); process.exit(1); }
+console.log('RESULT: PASS (no WCAG 2.1 A/AA violations)');

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,6 +57,17 @@ pre {
   overflow-wrap: anywhere;
 }
 
+/* WCAG 1.4.1 — colour must not be the ONLY way a link is identified. Inside a
+   text block a coloured word is indistinguishable from emphasis for anyone who
+   does not perceive that hue, and axe flagged 27 such links. Underline only
+   links sitting IN prose: navigation, cards and buttons are identifiable by
+   position and shape, so they are exempt and are left alone. */
+p a,
+li a {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
 body {
   background-color: var(--background);
   color: var(--text-primary);

--- a/src/components/token/TokenApp.tsx
+++ b/src/components/token/TokenApp.tsx
@@ -448,7 +448,9 @@ export default function TokenApp() {
         )}
         <p className={styles.muted}>Pick a round and answer its community quest (published on the PCO channels with its round id):</p>
         <p>
-          <select value={roundId} onChange={(e) => setRoundId(e.target.value)}>
+          {/* An accessible name is required: the visible label sits in a separate
+              paragraph, so a screen reader announced this only as "combo box". */}
+          <select aria-label="Claim round" value={roundId} onChange={(e) => setRoundId(e.target.value)}>
             {/* Each option carries its OWN remaining budget: with several rounds open,
                 which ones still have room is the thing being chosen between. */}
             {rounds.map((r) => (

--- a/src/styles/contracts.module.css
+++ b/src/styles/contracts.module.css
@@ -36,8 +36,15 @@
 }
 
 .card a {
-  color: #0070f3;
-  text-decoration: none;
+  /* Was a hardcoded #0070f3 — the one raw hex outside the token system, and it
+     failed WCAG AA on this background at 4.22:1 (needs 4.5). The brand link
+     token clears it at 7.65:1, so the accessible fix and the correct fix are
+     the same one. */
+  color: var(--text-link);
+  /* Inline within the card's description text, not a whole-card link, so it
+     needs a non-colour signal too (WCAG 1.4.1). */
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }
 
 .card a:hover {

--- a/src/styles/roadmap.module.css
+++ b/src/styles/roadmap.module.css
@@ -56,7 +56,10 @@
 
 .entry a {
   color: var(--primary);
-  text-decoration: none;
+  /* Sits inline within the entry's prose, so colour alone does not identify it
+     as a link (WCAG 1.4.1). */
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }
 
 .entry a:hover {

--- a/src/styles/token-banner.module.css
+++ b/src/styles/token-banner.module.css
@@ -20,7 +20,10 @@
 }
 .badge {
   background: var(--secondary, #FF4DE3);
-  color: #fff;
+  /* Dark on pink, not white on pink: white gave 2.81:1 against this background
+     and the badge is 0.7rem, so it needs 4.5:1. Reversing to the dark brand
+     colour gives 6.81:1 and keeps the pink. */
+  color: var(--background, #0F0D1A);
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.05em;

--- a/src/styles/token.module.css
+++ b/src/styles/token.module.css
@@ -32,7 +32,11 @@
 .info h2 { font-size: 1.4rem; margin: 2rem 0 0.75rem; }
 .info p, .info li { line-height: 1.65; color: var(--text-secondary); margin-bottom: 0.5rem; }
 .info ul { padding-left: 1.25rem; }
-.info a { color: var(--text-link); text-decoration: none; }
+/* Underlined ON PURPOSE (WCAG 1.4.1): .info holds the token page's prose, where
+   a link is a coloured word inside a sentence and colour alone does not identify
+   it. Card and nav links elsewhere keep text-decoration:none — they are
+   identifiable by position and shape, so the rule does not apply to them. */
+.info a { color: var(--text-link); text-decoration: underline; text-underline-offset: 0.15em; }
 .info a:hover { color: var(--text-link-hover); text-decoration: underline; }
 
 .app {


### PR DESCRIPTION
Closes #10.

The issue asked for an accessibility checklist. A checklist written from the standard rather than from the site is a document asserting compliance nobody measured — so this measures first. axe-core over all 13 routes found **three rules violated, 40 nodes, one critical**.

## What was actually wrong

| rule | impact | what it was |
|---|---|---|
| `select-name` | **CRITICAL** | The claim-round `<select>` had **no accessible name**. Its visible label sits in a separate paragraph, so a screen reader announced the site's primary control as *"combo box"*. |
| `color-contrast` | serious | A link hardcoded to `#0070f3` = **4.22:1** on the dark background (AA needs 4.5). The token banner badge was white-on-pink at **2.81:1**. |
| `link-in-text-block` | serious | **27 links** identified by colour alone (WCAG 1.4.1). |

**0 violations across 13 routes** after the fixes.

Worth noting: the contrast failure was the **one raw hex outside the token system**. Swapping it for `var(--text-link)` gives 7.65:1 — the accessible fix and the correct fix were the same change. The badge reverses to dark-on-pink at 6.79:1, keeping the brand colour rather than diluting it.

Links in prose are now underlined; navigation, cards and buttons are exempt — they are identifiable by position and shape, so the rule does not apply to them.

## New gate: `npm run a11y-check`

Neither lint nor build reads the accessibility tree. That is precisely why a control with **no name** shipped on the claim flow — the one journey used by people who have never held a token.

**Proven able to fail**, not just to pass: injecting a low-contrast rule into the built CSS produces 297 contrast violations; removing it returns to PASS.

⚠️ Note for anyone extending it: my first falsification attempt was invalid — I injected `.card a`, but **CSS Modules hash class names**, so the selector matched nothing and the gate "passed" for the wrong reason. Same class of mistake as injecting a DOM node into a hydrated app.

Best-practice findings are reported but do **not** fail the build: they are advice, and mixing them in makes a real failure easy to miss.

## `docs/accessibility-checklist.md`

Records the standard, what is enforced mechanically, the violations actually found, the rules for writing this site — and, deliberately, **what the tool does not cover** (screen-reader flow, keyboard journeys, contrast over gradients, content quality, cognitive load). axe catches roughly a third to a half of WCAG issues; a green run must never be read as "fully accessible".

## Verification

`lint` · `tsc --noEmit` · `build` · `mobile-check` (39 page-widths) · `a11y-check` (13 routes) — all clean. Badge and link rendering checked in a browser; nav links confirmed untouched.